### PR TITLE
Allow setting storage to :none for an experiment.

### DIFF
--- a/test/experiment_test.rb
+++ b/test/experiment_test.rb
@@ -309,4 +309,13 @@ class ExperimentTest < MiniTest::Unit::TestCase
     e.assign(stub(id: '123'))
     assert e.started?, "The experiment should have started after the first assignment"
   end
+
+  def test_no_storage
+    e = Verdict::Experiment.new('starting_test') do
+      groups { group :all, 100 }
+      storage :none
+    end
+
+    assert_kind_of Verdict::Storage::MockStorage, e.storage
+  end
 end


### PR DESCRIPTION
This will disable storing/caching subject assignments. This reduces overhead and required storage space for the experiment. 

We don't use the storage option for data analysis; we use the logging feature to create an audit trail for data analysis purposes. In our case this audit trail is pushed to Kafka.

In this case, you have to use a segmenter that will consistently segment an identifier to the same group. Also, you cannot assign or disqualify a subject by hand in this scenario. If the segmenter is heavy on CPU, this will also increase CPU usage.

Ergo: use this future with care.

@pseudomuto @peterjm @gmalette for review.
