### PR TITLE
Fix rake task to manually assign shops

### DIFF
--- a/lib/verdict/experiment.rb
+++ b/lib/verdict/experiment.rb
@@ -59,7 +59,7 @@ class Verdict::Experiment
 
   def storage(subject_storage = nil, options = {})
     return @subject_storage if subject_storage.nil?
-    
+
     @store_unqualified = options[:store_unqualified] if options.has_key?(:store_unqualified)
     @subject_storage = case subject_storage
       when :memory; Verdict::Storage::MemoryStorage.new
@@ -86,7 +86,7 @@ class Verdict::Experiment
     segmenter.groups.keys
   end
 
-  def subject_assignment(subject_identifier, group, originally_created_at, temporary = false)
+  def subject_assignment(subject_identifier, group, originally_created_at = nil, temporary = false)
     Verdict::Assignment.new(self, subject_identifier, group, originally_created_at, temporary)
   end
 

--- a/lib/verdict/tasks.rake
+++ b/lib/verdict/tasks.rake
@@ -34,14 +34,14 @@ namespace :experiments do
   task :assign_manually => 'environment' do
     experiment = Verdict[require_env('experiment')] or raise "Experiment not found"
     group = experiment.group(require_env('group')) or raise "Group not found"
-    assignment = experiment.subject_assignment(require_env('subject'), group, false)
+    assignment = experiment.subject_assignment(require_env('subject'), group)
     experiment.store_assignment(assignment)
   end
 
   desc "Disqualify a subject from an experiment"
   task :disqualify => 'environment' do
     experiment = Verdict[require_env('experiment')] or raise "Experiment not found"
-    assignment = experiment.subject_assignment(require_env('subject'), nil, false)
+    assignment = experiment.subject_assignment(require_env('subject'), nil)
     experiment.store_assignment(assignment)
   end
 


### PR DESCRIPTION
@wvanbergen @pseudomuto 
/cc @richgilbank 

Fixes #2 

The rake task was setting `originally_created_at` to false, instead of nil. That made `should_store_assignment?` return false, because `assignment.returning?` was true, because `@returning` is set to `!originally_created_at.nil?`.

BTW, I have _no idea_ what the `returning?` method is supposed to mean.
