### PR TITLE
Check that Railtie is defined before requiring verdict/railtie

### DIFF
--- a/lib/verdict.rb
+++ b/lib/verdict.rb
@@ -40,7 +40,7 @@ module Verdict
 end
 
 require "verdict/version"
-require "verdict/railtie" if defined?(Rails)
+require "verdict/railtie" if defined?(Rails::Railtie)
 
 require "verdict/metadata"
 require "verdict/experiment"


### PR DESCRIPTION
I'd like to use verdict with pre-Railtie Rails, specifically this forked [github/rails](https://github.com/github/rails) version. However, verdict requires a Railtie if `Rails` is defined. Would it be possible to check for `Rails::Railtie` explicitly instead to determine whether `verdict/railtie` should be `require`d?

cc @alindeman @grantr
