### PR TITLE
Add a segmenter that is non-deterministic

### DIFF
--- a/lib/verdict/segmenters.rb
+++ b/lib/verdict/segmenters.rb
@@ -1,4 +1,5 @@
 require 'verdict/segmenters/base_segmenter'
 require 'verdict/segmenters/static_segmenter'
 require 'verdict/segmenters/fixed_percentage_segmenter'
+require 'verdict/segmenters/random_percentage_segmenter'
 require 'verdict/segmenters/rollout_segmenter'

--- a/lib/verdict/segmenters/random_percentage_segmenter.rb
+++ b/lib/verdict/segmenters/random_percentage_segmenter.rb
@@ -1,0 +1,18 @@
+module Verdict
+  module Segmenters
+    class RandomPercentageSegmenter < FixedPercentageSegmenter
+
+      attr_accessor :random
+
+      def initialize(*args)
+        super
+        @random = Random.new
+      end
+
+      def assign(identifier, subject, context)
+        percentile = @random.rand(100)
+        groups.values.find { |group| group.percentile_range.include?(percentile) }
+      end
+    end
+  end
+end

--- a/test/segmenters/random_percentage_segmenter_test.rb
+++ b/test/segmenters/random_percentage_segmenter_test.rb
@@ -1,0 +1,37 @@
+require 'test_helper'
+
+class RandomPercentageSegmenterTest < Minitest::Test
+
+  def setup
+    @segmenter = Verdict::Segmenters::RandomPercentageSegmenter.new(Verdict::Experiment.new('test'))
+    @segmenter.group :segment1, 50
+    @segmenter.group :segment2, 50
+    @segmenter.verify!
+  end
+
+  def test_random_assignment
+    @segmenter.random = Random.new(1)
+
+    groups = { segment1: 0, segment2: 0 }
+    100.times do |n|
+      group = @segmenter.assign(n.to_s, nil, nil)
+      groups[group.handle.to_sym] += 1
+    end
+
+    assert_equal 54, groups[:segment1]
+    assert_equal 46, groups[:segment2]
+  end
+
+  def test_random_assignment_with_different_seed
+    @segmenter.random = Random.new(2)
+
+    groups = { segment1: 0, segment2: 0 }
+    100.times do |n|
+      group = @segmenter.assign(n.to_s, nil, nil)
+      groups[group.handle.to_sym] += 1
+    end
+
+    assert_equal 44, groups[:segment1]
+    assert_equal 56, groups[:segment2]
+  end
+end


### PR DESCRIPTION
In contrast with the fixed percentage segmenter which is deterministic based on the subject ID.

It's mostly intended for testing purposes: by using randomization, people need to do proper stubbing in  tests to get deterministic test results. This may catch some bugs related to experiments, e.g. the bahevior of one of the groups not bing tested at all.

@jeromecornet @peterjm @pseudomuto 
