### PR TITLE
Store experiment start dates in database

### DIFF
--- a/lib/verdict/storage/base_storage.rb
+++ b/lib/verdict/storage/base_storage.rb
@@ -34,12 +34,16 @@ module Verdict
       # Retrieves the start timestamp of the experiment
       def retrieve_start_timestamp(experiment)
         if timestamp = get(experiment.handle.to_s, 'started_at')
+          Experiments::ExperimentStartDate.store(experiment.handle.to_s, timestamp.to_time)
           Time.parse(timestamp)
         end
+      rescue Redis::CannotConnectError
+        Experiments::ExperimentStartDate.retrieve(experiment.handle.to_s)
       end
 
       # Stores the timestamp on which the experiment was started
       def store_start_timestamp(experiment, timestamp)
+        Experiments::ExperimentStartDate.store(experiment.handle.to_s, timestamp)
         set(experiment.handle.to_s, 'started_at', timestamp.utc.strftime('%FT%TZ'))
       end
 

--- a/lib/verdict/storage/legacy_redis_storage.rb
+++ b/lib/verdict/storage/legacy_redis_storage.rb
@@ -36,6 +36,7 @@ module Verdict
 
       def retrieve_start_timestamp(experiment)
         if started_at = redis.get(generate_experiment_start_timestamp_key(experiment))
+          Experiments::ExperimentStartDate.store(experiment.handle.to_s, started_at.to_time)
           DateTime.parse(started_at).to_time
         end
       rescue ::Redis::BaseError => e
@@ -43,6 +44,7 @@ module Verdict
       end
 
       def store_start_timestamp(experiment, timestamp)
+        Experiments::ExperimentStartDate.store(experiment.handle.to_s, timestamp)
         redis.setnx(generate_experiment_start_timestamp_key(experiment), timestamp.to_s)
       rescue ::Redis::BaseError => e
         raise Verdict::StorageError, "Redis error: #{e.message}"


### PR DESCRIPTION
This change is to slowly start migrating experiment start dates to the database for persistence. 
* For every call to `store_start_timestamp`, we store in both redis and sql.
* For every call to `retrieve_start_timestamp`, we check redis to see if it has a value. If so, we store to the database before returning the timestamp.

r @fbogsany @pallan 