### PR TITLE
Add `timestamps_out_of_band` option to Experiment

### DIFF
--- a/lib/verdict/assignment.rb
+++ b/lib/verdict/assignment.rb
@@ -1,12 +1,11 @@
 class Verdict::Assignment
-
   attr_reader :experiment, :subject_identifier, :group, :created_at
 
   def initialize(experiment, subject_identifier, group, originally_created_at, temporary = false)
     @experiment         = experiment
     @subject_identifier = subject_identifier
     @group              = group
-    @returning          = !originally_created_at.nil?
+    @first              = originally_created_at.nil? || experiment.timestamps_out_of_band?
     @created_at         = originally_created_at || Time.now.utc
     @temporary          = temporary
   end
@@ -32,7 +31,7 @@ class Verdict::Assignment
   end
 
   def returning?
-    @returning
+    !@first
   end
 
   def handle

--- a/lib/verdict/assignment.rb
+++ b/lib/verdict/assignment.rb
@@ -5,7 +5,7 @@ class Verdict::Assignment
     @experiment         = experiment
     @subject_identifier = subject_identifier
     @group              = group
-    @first              = originally_created_at.nil? || experiment.timestamps_out_of_band?
+    @first              = originally_created_at.nil? || experiment.manual_assignment_timestamps?
     @created_at         = originally_created_at || Time.now.utc
     @temporary          = temporary
   end
@@ -31,7 +31,7 @@ class Verdict::Assignment
   end
 
   def returning?
-    !@first
+    @first.nil?
   end
 
   def handle

--- a/lib/verdict/experiment.rb
+++ b/lib/verdict/experiment.rb
@@ -21,6 +21,7 @@ class Verdict::Experiment
     @segmenter                   = options[:segmenter]
     @subject_type                = options[:subject_type]
     @disqualify_empty_identifier = options[:disqualify_empty_identifier]
+    @timestamps_out_of_band      = options[:timestamps_out_of_band]
 
     instance_eval(&block) if block_given?
   end
@@ -33,6 +34,10 @@ class Verdict::Experiment
 
   def store_unqualified?
     @store_unqualified
+  end
+
+  def timestamps_out_of_band?
+    @timestamps_out_of_band
   end
 
   def group(handle)

--- a/lib/verdict/experiment.rb
+++ b/lib/verdict/experiment.rb
@@ -14,14 +14,14 @@ class Verdict::Experiment
     @handle = handle.to_s
 
     options = default_options.merge(options)
-    @qualifier                   = options[:qualifier]
-    @event_logger                = options[:event_logger] || Verdict::EventLogger.new(Verdict.default_logger)
-    @storage                     = storage(options[:storage] || :memory)
-    @store_unqualified           = options[:store_unqualified]
-    @segmenter                   = options[:segmenter]
-    @subject_type                = options[:subject_type]
-    @disqualify_empty_identifier = options[:disqualify_empty_identifier]
-    @timestamps_out_of_band      = options[:timestamps_out_of_band]
+    @qualifier                    = options[:qualifier]
+    @event_logger                 = options[:event_logger] || Verdict::EventLogger.new(Verdict.default_logger)
+    @storage                      = storage(options[:storage] || :memory)
+    @store_unqualified            = options[:store_unqualified]
+    @segmenter                    = options[:segmenter]
+    @subject_type                 = options[:subject_type]
+    @disqualify_empty_identifier  = options[:disqualify_empty_identifier]
+    @manual_assignment_timestamps = options[:manual_assignment_timestamps]
 
     instance_eval(&block) if block_given?
   end
@@ -36,8 +36,8 @@ class Verdict::Experiment
     @store_unqualified
   end
 
-  def timestamps_out_of_band?
-    @timestamps_out_of_band
+  def manual_assignment_timestamps?
+    @manual_assignment_timestamps
   end
 
   def group(handle)

--- a/test/assignment_test.rb
+++ b/test/assignment_test.rb
@@ -82,8 +82,8 @@ class AssignmentTest < Minitest::Test
     refute assignment_without_timestamp.returning?
   end
 
-  def test_returning_with_timestamps_out_of_band_experiment_option
-    experiment = Verdict::Experiment.new('assignment test', timestamps_out_of_band: true)
+  def test_returning_with_manual_assignment_timestamps_experiment_option
+    experiment = Verdict::Experiment.new('assignment test', manual_assignment_timestamps: true)
 
     assignment_with_timestamp = Verdict::Assignment.new(experiment, 'test_subject_id', @group, Time.now.utc)
     refute assignment_with_timestamp.returning?

--- a/test/assignment_test.rb
+++ b/test/assignment_test.rb
@@ -73,4 +73,22 @@ class AssignmentTest < Minitest::Test
       assert_equal '2012-01-01T00:00:00Z', json['created_at']
     end
   end
+
+  def test_returning_assignment
+    assignment_with_timestamp = Verdict::Assignment.new(@experiment, 'test_subject_id', @group, Time.now.utc)
+    assert assignment_with_timestamp.returning?
+
+    assignment_without_timestamp = Verdict::Assignment.new(@experiment, 'test_subject_id', @group, nil)
+    refute assignment_without_timestamp.returning?
+  end
+
+  def test_returning_with_timestamps_out_of_band_experiment_option
+    experiment = Verdict::Experiment.new('assignment test', timestamps_out_of_band: true)
+
+    assignment_with_timestamp = Verdict::Assignment.new(experiment, 'test_subject_id', @group, Time.now.utc)
+    refute assignment_with_timestamp.returning?
+
+    assignment_without_timestamp = Verdict::Assignment.new(experiment, 'test_subject_id', @group, nil)
+    refute assignment_without_timestamp.returning?
+  end
 end

--- a/test/experiment_test.rb
+++ b/test/experiment_test.rb
@@ -75,6 +75,22 @@ class ExperimentTest < Minitest::Test
     assert_equal nil, e.switch(3)
   end
 
+  def test_experiment_without_timestamps_out_of_band_option
+    e = Verdict::Experiment.new('test') do
+      groups { group :all, 100 }
+    end
+
+    refute e.timestamps_out_of_band?
+  end
+
+  def test_experiment_with_timestamps_out_of_band_option
+    e = Verdict::Experiment.new('test', timestamps_out_of_band: true) do
+      groups { group :all, 100 }
+    end   
+
+    assert e.timestamps_out_of_band?
+  end
+
   def test_subject_identifier
     e = Verdict::Experiment.new('test')
     assert_equal '123', e.retrieve_subject_identifier(stub(id: 123, to_s: '456'))

--- a/test/experiment_test.rb
+++ b/test/experiment_test.rb
@@ -75,20 +75,20 @@ class ExperimentTest < Minitest::Test
     assert_equal nil, e.switch(3)
   end
 
-  def test_experiment_without_timestamps_out_of_band_option
+  def test_experiment_without_manual_assignment_timestamps_option
     e = Verdict::Experiment.new('test') do
       groups { group :all, 100 }
     end
 
-    refute e.timestamps_out_of_band?
+    refute e.manual_assignment_timestamps?
   end
 
-  def test_experiment_with_timestamps_out_of_band_option
-    e = Verdict::Experiment.new('test', timestamps_out_of_band: true) do
+  def test_experiment_with_manual_assignment_timestamps_option
+    e = Verdict::Experiment.new('test', manual_assignment_timestamps: true) do
       groups { group :all, 100 }
     end   
 
-    assert e.timestamps_out_of_band?
+    assert e.manual_assignment_timestamps?
   end
 
   def test_subject_identifier


### PR DESCRIPTION
## What

This PR adds a boolean `timestamps_out_of_band` option to `Verdict::Experiment`, to be used as an override in the `Verdict::Assignment` constructor when initializing its `@returning` attribute and `#returning?` method. 

Right now, the `Verdict::Assignment`' [constructor](https://github.com/Shopify/verdict/blob/master/lib/verdict/assignment.rb#L9) is designed to assume that instances created with a non nil `originally_created_at` timestamp are `#returning?` assignments that had been assigned previously and are being fetched. 

Having this option set to true allows us to set the timestamp of an experiment assignment with [experiment#subject_assignment](https://github.com/Shopify/verdict/blob/master/lib/verdict/experiment.rb#L91) when creating it manually, and have it considered to be a newly created assignment and not `returning?`

See https://github.com/Shopify/shopify/pull/63398 for more context.

## Why 

We want to use Verdict with mobile apps, which will do the qualification and segmenting logic locally, and then self assign into verdict experiments defined server side. 

Mobile apps go offline a lot, so we stash the assignment timestamps ourselves when they happen, and then send them out of band at the next opportunity. Often, the time that event happened will be behind the time the assignment is created on the server. 

## Review 

@wvanbergen @pseudomuto  any thoughts? 

This was cleaner for our use case than overriding the assignment constructor locally, or having it return `returning?` assignments but then hack around them [during logging](https://github.com/Shopify/shopify/blob/master/app/models/experiments/kafka_event_logging.rb#L4). I'm down to consider other solutions if you think this is too obscure. There's already a lot of options and overrides in both of these classes. 

cc: @RyanBillard 