### PR TITLE
Tweaking Travis for Green

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: ruby
+cache: bundler
+before_install: gem update bundler
 script: bundle exec rake
 rvm:
   - 1.9.3


### PR DESCRIPTION
@ohsabry @wvanbergen 

# The Problem

There was an issue in bundler the causes a NoMethodError (spec undefined for nil:NilClass). It looks like recent versions of ruby on travis are ok, but 1.9.3 needs to update bundler before installing (see [this PR](https://github.com/bundler/bundler/pull/3559) for details ~ April 2015).

# The Solution

Tell travis to update bundler before installing. I've also cached bundles for faster CI runs (auto updates if the bundle is updated).