### PR TITLE
bump version to 0.5.0

### DIFF
--- a/lib/verdict/version.rb
+++ b/lib/verdict/version.rb
@@ -1,3 +1,3 @@
 module Verdict
-  VERSION = "0.4.1"
+  VERSION = "0.5.0"
 end


### PR DESCRIPTION
Bumping minor version of the gem after adding a new backwards compatible feature in https://github.com/Shopify/verdict/pull/16

Will rebase after @pseudomuto's bundler fix before merging. 

@pseudomuto @wvanbergen 