### PR TITLE
Apply sorting in repository getter

### DIFF
--- a/lib/verdict.rb
+++ b/lib/verdict.rb
@@ -16,7 +16,7 @@ module Verdict
       discovery
     end
 
-    @repository
+    Hash[@repository.sort]
   end
 
   def discovery


### PR DESCRIPTION
Ruby hashes preserves the ordering of items inserted into it and as a result, `Verdict.repository` can have different orderings which are machine/OS-dependent.  This enforces a certain ordering on the hash returned, which is more reliable.