### PR TITLE
Fix issues related to holding references to autoloaded code

### DIFF
--- a/lib/verdict.rb
+++ b/lib/verdict.rb
@@ -20,7 +20,11 @@ module Verdict
   end
 
   def discovery
-    Dir[File.join(Verdict.directory, '**', '*.rb')].each { |f| require f } if @directory
+    Dir[File.join(Verdict.directory, '**', '*.rb')].each { |f| load f } if @directory
+  end
+
+  def clear_respository_cache
+    @repository = nil
   end
 
   class Error < StandardError; end

--- a/lib/verdict.rb
+++ b/lib/verdict.rb
@@ -11,19 +11,16 @@ module Verdict
   end
 
   def repository
-    if @repository.nil?
-      @repository = {}
-      discovery
-    end
-
+    discovery if @repository.nil?
     @repository
   end
 
   def discovery
+    @repository = {}
     Dir[File.join(Verdict.directory, '**', '*.rb')].each { |f| load f } if @directory
   end
 
-  def clear_respository_cache
+  def clear_repository_cache
     @repository = nil
   end
 


### PR DESCRIPTION
Verdict currently holds references to all experiments in
`Verdict.respository`. A common use case for Verdict is to subclass
`Verdict::Experiment` to add your own behaviour. This is problematic
when the subclasses are autoloaded by Rails and can cause Rails to raise
the following exception:

> "ArgumentError: A copy of _Some::Experiment_ has been removed from the
module tree but is still active!"

The fix for this is to provide a mechanism by which we can trigger
Verdict to reload its experiments via an ActiveSupport `to_prepare`
block in `config/environments/development.rb`. This PR adds the
following:

 - A new method `Verdict.clear_repository_cache` which nils out the
 repository instance variable so the next call to `Verdict[]` will
 trigger reloading all experiments. This can be called in a `to_prepare`
 block in your Rails development config.

 - Changes the load strategy in `Verdict.discovery` from `require` to
 `load` so the experiment files can be loaded again. Note that this has
 the side effect that `Verdict.discovery` cannot be called twice without
 calling `Verdict.clear_repository_cache` in between.

@eljojo @wvanbergen 