### PR TITLE
Ensure that the eagerload paths are re-frozen after being reassigned (as plain old Rails would be)

### DIFF
--- a/lib/verdict/railtie.rb
+++ b/lib/verdict/railtie.rb
@@ -4,6 +4,8 @@ class Verdict::Railtie < Rails::Railtie
     Verdict.directory = Rails.root.join('app', 'experiments')
 
     app.config.eager_load_paths -= [Verdict.directory.to_s]
+    # Re-freeze eager load paths to ensure they blow up if modified at runtime, as Rails does
+    app.config.eager_load_paths.freeze
   end
 
   rake_tasks do


### PR DESCRIPTION
Rails [freezes](https://github.com/rails/rails/blob/master/railties/lib/rails/engine.rb#L571) the `config.*_paths` arrays once it starts initializing for sanity. It'd really suck if sometimes code loading worked and sometimes it didn't based on what controllers had been autoloaded already or something like that, so Rails mandates that all changes to the load paths happen during initialization and never after by making the paths impossible to change at a certain during initialization (linked above).

This railtie however reassigns to the config object an entirely new (filtered) Array object that isn't frozen, so now, the eager load paths could be changed at runtime without any issue! 

I think we should maintain Rails' semantics for these objects and freeze this sucker after fiddling with it. 