### PR TITLE
Integrate Verdict.clear_repository_cache with our railtie

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v0.6.2
+
+* Implement Verdict.clear_repository_cache, which fixes autoloading issues with Rails.
+* Integrated Verdict.clear_repository_cache with our Railtie.
+
 ## v0.6.1
 
 * Make Verdict Railtie `.freeze` the eager_load_paths it changes as Rails itself does.

--- a/lib/verdict/railtie.rb
+++ b/lib/verdict/railtie.rb
@@ -8,6 +8,11 @@ class Verdict::Railtie < Rails::Railtie
     app.config.eager_load_paths.freeze
   end
 
+  config.to_prepare do
+    # Clear Verdict's cache in order to avoid "A copy of ... has been removed from the module tree but is still active!"
+    Verdict.clear_repository_cache
+  end
+
   rake_tasks do
     load File.expand_path("./tasks.rake", File.dirname(__FILE__))
   end


### PR DESCRIPTION
Following up on #25, turns out we can integrate `Verdict.clear_repository_cache` directly in our railtie, so we don't have to ask whoever uses the gem to add it to their env file.

tophatted locally and it works perfectly.