### PR TITLE
Fix Verdict.directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v0.6.3
+
+* Fix bug were Verdict.directory is overwritten
+* Allow Verdict.directory to handle multiple directories (using globbing)
+
 ## v0.6.2
 
 * Implement Verdict.clear_repository_cache, which fixes autoloading issues with Rails.

--- a/lib/verdict/railtie.rb
+++ b/lib/verdict/railtie.rb
@@ -1,9 +1,10 @@
 class Verdict::Railtie < Rails::Railtie
   initializer "experiments.configure_rails_initialization" do |app|
     Verdict.default_logger = Rails.logger
-    Verdict.directory = Rails.root.join('app', 'experiments')
 
-    app.config.eager_load_paths -= [Verdict.directory.to_s]
+    Verdict.directory ||= Rails.root.join('app', 'experiments')
+    app.config.eager_load_paths -= Dir[Verdict.directory.to_s]
+
     # Re-freeze eager load paths to ensure they blow up if modified at runtime, as Rails does
     app.config.eager_load_paths.freeze
   end

--- a/lib/verdict/version.rb
+++ b/lib/verdict/version.rb
@@ -1,3 +1,3 @@
 module Verdict
-  VERSION = "0.6.2"
+  VERSION = "0.6.3"
 end


### PR DESCRIPTION
This PR does two things:
- fixes a bug in Verdict where Verdict.directory is being overwritten
- Uses directory globbing on Verdict.directory, so we can define `Verdict.directory = "#{Rails.root}/whatever/*/app/experiments"`

Thanks to @kirs for pointing out we're overwriting `Verdict.directory` :)