### PR TITLE
Multiple qualify blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## v0.7.0
+**This version has breaking changes**
+
+* Experiment can now specify multiple qualify blocks
+  * `Verdict::Experiment#qualifier` has been removed in favor for `Verdict::Experiment#qualifiers`, which returns an array of procs
+* Allow pass of an argument to qualify with a method name as a symbol, instead of a block
+
 ## v0.6.3
 
 * Fix bug were Verdict.directory is overwritten

--- a/lib/verdict/experiment.rb
+++ b/lib/verdict/experiment.rb
@@ -2,7 +2,7 @@ class Verdict::Experiment
 
   include Verdict::Metadata
 
-  attr_reader :handle, :qualifier, :storage, :event_logger
+  attr_reader :handle, :qualifiers, :storage, :event_logger
 
   def self.define(handle, *args, &block)
     experiment = self.new(handle, *args, &block)
@@ -14,7 +14,7 @@ class Verdict::Experiment
     @handle = handle.to_s
 
     options = default_options.merge(options)
-    @qualifier                    = options[:qualifier]
+    @qualifiers                   = Array(options[:qualifier] || options[:qualifiers])
     @event_logger                 = options[:event_logger] || Verdict::EventLogger.new(Verdict.default_logger)
     @storage                      = storage(options[:storage] || :memory)
     @store_unqualified            = options[:store_unqualified]
@@ -59,7 +59,7 @@ class Verdict::Experiment
   end
 
   def qualify(&block)
-    @qualifier = block
+    @qualifiers << block
   end
 
   def storage(storage = nil, options = {})
@@ -169,7 +169,7 @@ class Verdict::Experiment
   end
 
   def has_qualifier?
-    !@qualifier.nil?
+    @qualifiers.any?
   end
 
   def everybody_qualifies?
@@ -204,7 +204,7 @@ class Verdict::Experiment
 
   def subject_qualifies?(subject, context = nil)
     ensure_experiment_has_started
-    everybody_qualifies? || @qualifier.call(subject, context)
+    everybody_qualifies? || @qualifiers.all? { |qualifier| qualifier.call(subject, context) }
   end
 
   protected

--- a/lib/verdict/experiment.rb
+++ b/lib/verdict/experiment.rb
@@ -58,8 +58,16 @@ class Verdict::Experiment
     end
   end
 
-  def qualify(&block)
-    @qualifiers << block
+  def qualify(method_name = nil, &block)
+    if block_given?
+      @qualifiers << block
+    elsif method_name.nil?
+      raise ArgumentError, "no method nor blocked passed!"
+    elsif respond_to?(method_name, true)
+      @qualifiers << method(method_name).to_proc
+    else
+      raise ArgumentError, "No helper for #{method_name.inspect}"
+    end
   end
 
   def storage(storage = nil, options = {})

--- a/lib/verdict/version.rb
+++ b/lib/verdict/version.rb
@@ -1,3 +1,3 @@
 module Verdict
-  VERSION = "0.6.3"
+  VERSION = "0.7.0"
 end

--- a/test/experiment_test.rb
+++ b/test/experiment_test.rb
@@ -5,7 +5,7 @@ class ExperimentTest < Minitest::Test
 
   def test_no_qualifier
     e = Verdict::Experiment.new('test')
-    assert !e.has_qualifier?
+    refute e.has_qualifier?
     assert e.everybody_qualifies?
   end
 
@@ -18,14 +18,14 @@ class ExperimentTest < Minitest::Test
     end
 
     assert e.has_qualifier?
-    assert !e.everybody_qualifies?
+    refute e.everybody_qualifies?
 
     subject_stub = Struct.new(:id, :country)
     ca_subject = subject_stub.new(1, 'CA')
     us_subject = subject_stub.new(1, 'US')
 
     assert e.qualifiers.all? { |q| q.call(ca_subject) }
-    assert !e.qualifiers.all? { |q| q.call(us_subject) }
+    refute e.qualifiers.all? { |q| q.call(us_subject) }
 
     qualified = e.assign(ca_subject)
     assert_kind_of Verdict::Assignment, qualified
@@ -33,7 +33,7 @@ class ExperimentTest < Minitest::Test
 
     non_qualified = e.assign(us_subject)
     assert_kind_of Verdict::Assignment, non_qualified
-    assert !non_qualified.qualified?
+    refute non_qualified.qualified?
     assert_equal nil, non_qualified.group
   end
 
@@ -48,14 +48,14 @@ class ExperimentTest < Minitest::Test
     end
 
     assert e.has_qualifier?
-    assert !e.everybody_qualifies?
+    refute e.everybody_qualifies?
 
     subject_stub = Struct.new(:id, :country, :language)
     fr_subject = subject_stub.new(1, 'CA', 'fr')
     en_subject = subject_stub.new(2, 'CA', 'en')
 
     assert e.qualifiers.all? { |q| q.call(fr_subject) }
-    assert !e.qualifiers.all? { |q| q.call(en_subject) }
+    refute e.qualifiers.all? { |q| q.call(en_subject) }
 
     qualified = e.assign(fr_subject)
     assert_kind_of Verdict::Assignment, qualified
@@ -63,7 +63,44 @@ class ExperimentTest < Minitest::Test
 
     non_qualified = e.assign(en_subject)
     assert_kind_of Verdict::Assignment, non_qualified
-    assert !non_qualified.qualified?
+    refute non_qualified.qualified?
+    assert_equal nil, non_qualified.group
+  end
+
+  module CountryIsCanadaHelper
+    def country_is_canada(subject, _context)
+      subject.country == 'CA'
+    end
+  end
+  def test_method_qualifier
+
+    e = Verdict::Experiment.new('test') do |experiment|
+      extend CountryIsCanadaHelper
+
+      qualify :country_is_canada
+
+      groups do
+        group :all, 100
+      end
+    end
+
+    assert e.has_qualifier?
+    refute e.everybody_qualifies?
+
+    subject_stub = Struct.new(:id, :country)
+    ca_subject = subject_stub.new(1, 'CA')
+    us_subject = subject_stub.new(1, 'US')
+
+    assert e.qualifiers.all? { |q| q.call(ca_subject, nil) }
+    refute e.qualifiers.all? { |q| q.call(us_subject, nil) }
+
+    qualified = e.assign(ca_subject)
+    assert_kind_of Verdict::Assignment, qualified
+    assert_equal e.group(:all), qualified.group
+
+    non_qualified = e.assign(us_subject)
+    assert_kind_of Verdict::Assignment, non_qualified
+    refute non_qualified.qualified?
     assert_equal nil, non_qualified.group
   end
 
@@ -75,7 +112,7 @@ class ExperimentTest < Minitest::Test
       end
     end
 
-    assert !e.assign(nil).qualified?
+    refute e.assign(nil).qualified?
     assert_equal nil, e.convert('', :mygoal)
   end
 
@@ -93,12 +130,12 @@ class ExperimentTest < Minitest::Test
     assignment = e.assign(1)
     assert_kind_of Verdict::Assignment, assignment
     assert assignment.qualified?
-    assert !assignment.returning?
+    refute assignment.returning?
     assert_equal assignment.group, e.group(:a)
 
     assignment = e.assign(3)
     assert_kind_of Verdict::Assignment, assignment
-    assert !assignment.qualified?
+    refute assignment.qualified?
 
     assert_equal :a,  e.switch(1)
     assert_equal :b,  e.switch(2)
@@ -205,7 +242,7 @@ class ExperimentTest < Minitest::Test
     original_assignment = e.assign(subject)
     assert original_assignment.qualified?
     new_assignment = e.disqualify_manually(subject)
-    assert !new_assignment.qualified?
+    refute new_assignment.qualified?
   end
 
   def test_disqualify_manually_fails_with_store_unqualified_disabled
@@ -242,7 +279,7 @@ class ExperimentTest < Minitest::Test
     mock_store.expects(:store_assignment).never
 
     assignment = e.assign(mock('subject'))
-    assert !assignment.qualified?
+    refute assignment.qualified?
   end
 
   def test_assignment_event_logging
@@ -303,7 +340,7 @@ class ExperimentTest < Minitest::Test
 
     storage_mock.stubs(:retrieve_assignment).raises(Verdict::StorageError, 'storage read issues')
     rescued_assignment = e.assign(stub(id: 123))
-    assert !rescued_assignment.qualified?
+    refute rescued_assignment.qualified?
   end
 
   def test_storage_write_failure
@@ -316,7 +353,7 @@ class ExperimentTest < Minitest::Test
     storage_mock.expects(:retrieve_assignment).returns(e.subject_assignment(mock('subject_identifier'), e.group(:all), nil))
     storage_mock.expects(:store_assignment).raises(Verdict::StorageError, 'storage write issues')
     rescued_assignment = e.assign(stub(id: 456))
-    assert !rescued_assignment.qualified?
+    refute rescued_assignment.qualified?
   end
 
   def test_initial_started_at
@@ -358,7 +395,7 @@ class ExperimentTest < Minitest::Test
       end
 
       subject = stub(id: 'old', created_at: Time.new(2011))
-      assert !e.assign(subject).qualified?
+      refute e.assign(subject).qualified?
 
       subject = stub(id: 'new', created_at: Time.new(2013))
       assert e.assign(subject).qualified?
@@ -370,7 +407,7 @@ class ExperimentTest < Minitest::Test
       groups { group :all, 100 }
     end
 
-    assert !e.started?, "The experiment should not have started yet"
+    refute e.started?, "The experiment should not have started yet"
 
     e.assign(stub(id: '123'))
     assert e.started?, "The experiment should have started after the first assignment"


### PR DESCRIPTION
Allow Experiment definitions to
- specify multiple `qualify` blocks
- allow pass of an argument with a method name as a symbol, instead of a block (like AR validations)