### PR TITLE
try building with jruby-head

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ rvm:
   - 2.1
   - 2.3.3
   - ruby-head
-  - jruby
+  - jruby-head
 matrix:
   allow_failures:
     - rvm: ruby-head

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ rvm:
   - 2.1
   - 2.3.3
   - ruby-head
-  - jruby-head
+  - jruby
 matrix:
   allow_failures:
     - rvm: ruby-head


### PR DESCRIPTION
Travis CI fails to build. 
https://travis-ci.org/Shopify/verdict/jobs/312084986
> Unknown ruby string (do not know how to handle): jruby-9.1.14.0200.
> Requested binary installation but no rubies are available to download, consider skipping --binary flag.
> Gemset '' does not exist, 'rvm jruby-9.1.14.0200 do rvm gemset create ' first, or append '--create'.

Switching to `- jruby-head` in `.travis.yml` solves the issue.

I left both options to make sure it wasn't just a build fluke. I'd squash if this is approved.