### PR TITLE
Memoize the directory traversal as it can be expensive.

### DIFF
--- a/lib/verdict.rb
+++ b/lib/verdict.rb
@@ -17,7 +17,9 @@ module Verdict
 
   def discovery
     @repository = {}
-    Dir[File.join(Verdict.directory, '**', '*.rb')].each { |f| load f } if @directory
+    @discovery ||= if @directory
+      Dir[File.join(Verdict.directory, '**', '*.rb')].each { |f| load f }
+    end
   end
 
   def clear_repository_cache


### PR DESCRIPTION
This directory traversal can be very expensive on large projects. We should only pay that cost once.