### PR TITLE
Eagerly load discovery method

### DIFF
--- a/lib/verdict/railtie.rb
+++ b/lib/verdict/railtie.rb
@@ -12,6 +12,7 @@ class Verdict::Railtie < Rails::Railtie
   config.to_prepare do
     # Clear Verdict's cache in order to avoid "A copy of ... has been removed from the module tree but is still active!"
     Verdict.clear_repository_cache
+    Verdict.discovery
   end
 
   rake_tasks do

--- a/test/app/experiments/test_rails_app_experiment.rb
+++ b/test/app/experiments/test_rails_app_experiment.rb
@@ -1,0 +1,10 @@
+Verdict::Experiment.define(:test_rails_app_experiment) do
+  qualify { true }
+
+  groups do
+    group(:test, 4)
+    group(:control, :rest)
+  end
+
+  storage(Verdict::Storage::RedisStorage.new(Redis.current))
+end

--- a/test/assignment_test.rb
+++ b/test/assignment_test.rb
@@ -20,11 +20,11 @@ class AssignmentTest < Minitest::Test
     assert_kind_of Time, assignment.created_at
 
     non_assignment = Verdict::Assignment.new(@experiment, 'test_subject_id', nil, nil)
-    assert_equal nil, non_assignment.group
+    assert_nil non_assignment.group
     assert !non_assignment.returning?
     assert !non_assignment.qualified?
-    assert_equal nil, non_assignment.to_sym
-    assert_equal nil, non_assignment.handle
+    assert_nil non_assignment.to_sym
+    assert_nil non_assignment.handle
     assert_kind_of Time, assignment.created_at
   end
 
@@ -68,7 +68,7 @@ class AssignmentTest < Minitest::Test
       assert_equal 'test_subject_id', json['subject']
       assert_equal false, json['qualified']
       assert_equal false, json['returning']
-      assert_equal nil, json['group']
+      assert_nil json['group']
       assert_equal '2012-01-01T00:00:00Z', json['created_at']
     end
   end

--- a/test/experiment_test.rb
+++ b/test/experiment_test.rb
@@ -34,7 +34,7 @@ class ExperimentTest < Minitest::Test
     non_qualified = e.assign(us_subject)
     assert_kind_of Verdict::Assignment, non_qualified
     refute non_qualified.qualified?
-    assert_equal nil, non_qualified.group
+    assert_nil non_qualified.group
   end
 
   def test_multiple_qualifier
@@ -64,7 +64,7 @@ class ExperimentTest < Minitest::Test
     non_qualified = e.assign(en_subject)
     assert_kind_of Verdict::Assignment, non_qualified
     refute non_qualified.qualified?
-    assert_equal nil, non_qualified.group
+    assert_nil non_qualified.group
   end
 
   module CountryIsCanadaHelper
@@ -101,7 +101,7 @@ class ExperimentTest < Minitest::Test
     non_qualified = e.assign(us_subject)
     assert_kind_of Verdict::Assignment, non_qualified
     refute non_qualified.qualified?
-    assert_equal nil, non_qualified.group
+    assert_nil non_qualified.group
   end
 
   def test_disqualify_empty_identifier
@@ -113,7 +113,7 @@ class ExperimentTest < Minitest::Test
     end
 
     refute e.assign(nil).qualified?
-    assert_equal nil, e.convert('', :mygoal)
+    assert_nil e.convert('', :mygoal)
   end
 
   def test_assignment
@@ -139,7 +139,7 @@ class ExperimentTest < Minitest::Test
 
     assert_equal :a,  e.switch(1)
     assert_equal :b,  e.switch(2)
-    assert_equal nil, e.switch(3)
+    assert_nil e.switch(3)
   end
 
   def test_experiment_without_manual_assignment_timestamps_option

--- a/test/fake_app.rb
+++ b/test/fake_app.rb
@@ -1,0 +1,12 @@
+require 'rails'
+require "active_model/railtie"
+require "action_controller/railtie"
+require "action_view/railtie"
+require "verdict/railtie"
+
+# Create a rails app
+module Dummy
+  class Application < Rails::Application
+    config.root = "test"
+  end
+end

--- a/test/rake_tasks_test.rb
+++ b/test/rake_tasks_test.rb
@@ -12,7 +12,7 @@ class RakeTasksTest < Minitest::Test
 
   def setup
     require 'rake' unless defined?(Rake)
-    Rake::Task.define_task(:environment) 
+    Rake::Task.define_task(:environment)
     Rake.application.rake_require('verdict/tasks')
 
     @experiment = TestExperiment.define(:rake, store_unqualified: true) do

--- a/test/segmenters/static_segmenter_test.rb
+++ b/test/segmenters/static_segmenter_test.rb
@@ -20,6 +20,6 @@ class StaticSegmenterTest < Minitest::Test
 
   def test_assigment
     assert_equal @segmenter.groups['beta'], @segmenter.assign('id2', stub(id: 'id2'), nil)
-    assert_equal nil, @segmenter.assign('id3', stub(id: 'id3'), nil)
+    assert_nil @segmenter.assign('id3', stub(id: 'id3'), nil)
   end
 end

--- a/test/storage/legacy_redis_storage_test.rb
+++ b/test/storage/legacy_redis_storage_test.rb
@@ -50,7 +50,8 @@ class LegacyRedisStorageTest < Minitest::Test
     returning_assignment = @experiment.assign('subject_2')
     assert returning_assignment.returning?
     assert_equal new_assignment.experiment, returning_assignment.experiment
-    assert_equal new_assignment.group, returning_assignment.group
+    assert_nil new_assignment.group
+    assert_nil returning_assignment.group
   end
 
   def test_assign_should_return_unqualified_when_redis_is_unavailable_for_reads

--- a/test/storage/redis_storage_test.rb
+++ b/test/storage/redis_storage_test.rb
@@ -47,7 +47,8 @@ class RedisStorageTest < Minitest::Test
     returning_assignment = @experiment.assign('subject_2')
     assert returning_assignment.returning?
     assert_equal new_assignment.experiment, returning_assignment.experiment
-    assert_equal new_assignment.group, returning_assignment.group
+    assert_nil new_assignment.group
+    assert_nil returning_assignment.group
   end
 
   def test_assign_should_return_unqualified_when_redis_is_unavailable_for_reads

--- a/test/verdict_rails_test.rb
+++ b/test/verdict_rails_test.rb
@@ -1,0 +1,19 @@
+require 'test_helper'
+require 'fake_app'
+
+class VerdictRailsTest < Minitest::Test
+  def setup
+    Verdict.clear_repository_cache
+    new_rails_app = Dummy::Application.new
+    new_rails_app.initialize!
+  end
+
+  def test_verdict_railtie_should_find_directory_path
+    assert_equal Verdict.directory, Rails.root.join('app', 'experiments')
+  end
+
+  def test_verdict_should_eager_load_discovery
+    expected_experiment = Verdict.instance_variable_get('@repository')
+    assert expected_experiment.include?("test_rails_app_experiment")
+  end
+end

--- a/verdict.gemspec
+++ b/verdict.gemspec
@@ -22,4 +22,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency("mocha")
   gem.add_development_dependency("timecop")
   gem.add_development_dependency("redis")
+  gem.add_development_dependency("rails")
 end


### PR DESCRIPTION
Addresses issue #43 

Eagerly loads the discovery method within `railtie.rb` within the `config.to_prepare` method which will only have `Verdict.discovery` called once in production at the beginning.

Also added a new `verdict_rails_test.rb` file that tests verdict within a rails application and also added a mock experiement for the fake rails application to load to test.

Top Hating  🎩 : 

Currently I've tested it within the help application and within core as a dependency. 

To run tests be sure to have a redis server running and run `rake test`


 

