### PR TITLE
Fix typo in Experiment#fetch_subject

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+* Fix typo in `Experiment#fetch_subject` error message.
+
 ## v0.9.0
 **This version has breaking changes**
 * Eagerly load experiment definitions when booting Rails, so that multi-threaded applications do not face a race-condition when populating experiments.

--- a/lib/verdict/experiment.rb
+++ b/lib/verdict/experiment.rb
@@ -207,7 +207,7 @@ class Verdict::Experiment
   end
 
   def fetch_subject(subject_identifier)
-    raise NotImplementedError, "Fetching subjects based in identifier is not implemented for experiment #{@handle.inspect}."
+    raise NotImplementedError, "Fetching subjects based on identifier is not implemented for experiment #{@handle.inspect}."
   end
 
   def disqualify_empty_identifier?

--- a/lib/verdict/experiment.rb
+++ b/lib/verdict/experiment.rb
@@ -207,7 +207,7 @@ class Verdict::Experiment
   end
 
   def fetch_subject(subject_identifier)
-    raise NotImplementedError, "Fetching subjects based in identifier is not implemented for experiment @{handle.inspect}."
+    raise NotImplementedError, "Fetching subjects based in identifier is not implemented for experiment #{@handle.inspect}."
   end
 
   def disqualify_empty_identifier?


### PR DESCRIPTION
This PR fixes a typo in the default `NotImplementedError` raised by `Experiment.fetch_subject`.

**Before**:

```
NotImplementedError: Fetching subjects based in identifier is not implemented for experiment @{handle.inspect}.
```

**After**:

```
NotImplementedError: Fetching subjects based in identifier is not implemented for experiment "test_experiment".
```