### PR TITLE
Add Verdict::Experiment#cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+* Add `Experiment#cleanup` to remove stored redis hashes.
+
 * Fix typo in `Experiment#fetch_subject` error message.
 
 ## v0.9.0

--- a/lib/verdict/experiment.rb
+++ b/lib/verdict/experiment.rb
@@ -162,6 +162,10 @@ class Verdict::Experiment
     assignment
   end
 
+  def cleanup
+    @storage.cleanup(handle.to_s)
+  end
+
   def remove_subject_assignment(subject)
     @storage.remove_assignment(self, subject)
   end

--- a/lib/verdict/storage/base_storage.rb
+++ b/lib/verdict/storage/base_storage.rb
@@ -45,6 +45,10 @@ module Verdict
         set(experiment.handle.to_s, 'started_at', timestamp.utc.strftime('%FT%TZ'))
       end
 
+      def cleanup(_scope)
+        raise NotImplementedError
+      end
+
       protected
       # Retrieves a key in a given scope from storage.
       # - The scope and key are both provided as string.

--- a/lib/verdict/storage/redis_storage.rb
+++ b/lib/verdict/storage/redis_storage.rb
@@ -1,6 +1,8 @@
 module Verdict
   module Storage
     class RedisStorage < BaseStorage
+      PAGE_SIZE = 50
+
       attr_accessor :redis, :key_prefix
 
       def initialize(redis = nil, options = {})
@@ -9,27 +11,49 @@ module Verdict
       end
 
       def get(scope, key)
-        redis.hget("#{@key_prefix}#{scope}", key)
+        redis.hget(scope_key(scope), key)
       rescue ::Redis::BaseError => e
         raise Verdict::StorageError, "Redis error: #{e.message}"
       end
 
       def set(scope, key, value)
-        redis.hset("#{@key_prefix}#{scope}", key, value)
+        redis.hset(scope_key(scope), key, value)
       rescue ::Redis::BaseError => e
         raise Verdict::StorageError, "Redis error: #{e.message}"
       end
 
       def remove(scope, key)
-        redis.hdel("#{@key_prefix}#{scope}", key)
+        redis.hdel(scope_key(scope), key)
+      rescue ::Redis::BaseError => e
+        raise Verdict::StorageError, "Redis error: #{e.message}"
+      end
+
+      def cleanup(scope)
+        temp_scope = move_to_temp(scope)
+        clear(temp_scope)
+        redis.del(scope_key(temp_scope))
       rescue ::Redis::BaseError => e
         raise Verdict::StorageError, "Redis error: #{e.message}"
       end
 
       private
 
-      def generate_scope_key(scope)
+      def scope_key(scope)
         "#{@key_prefix}#{scope}"
+      end
+
+      def move_to_temp(scope)
+        "temp:#{SecureRandom.uuid}".tap do |temp_scope|
+          redis.rename(scope_key(scope), scope_key(temp_scope))
+        end
+      end
+
+      def clear(scope, cursor: 0)
+        cursor, results = redis.hscan(scope_key(scope), cursor, count: PAGE_SIZE)
+        results.map(&:first).each do |key|
+          remove(scope, key)
+        end
+        clear(scope, cursor: cursor) unless cursor.to_i.zero?
       end
     end
   end


### PR DESCRIPTION
Adds a way to clean up experiments (specifically when you store them in redis). This no-ops for other storage methods that don't require a cleanup step.