### PR TITLE
Don't rename redis experiment key when cleaning up

### DIFF
--- a/lib/verdict/storage/redis_storage.rb
+++ b/lib/verdict/storage/redis_storage.rb
@@ -29,9 +29,8 @@ module Verdict
       end
 
       def cleanup(scope)
-        temp_scope = move_to_temp(scope)
-        clear(temp_scope)
-        redis.del(scope_key(temp_scope))
+        clear(scope)
+        redis.del(scope_key(scope))
       rescue ::Redis::BaseError => e
         raise Verdict::StorageError, "Redis error: #{e.message}"
       end
@@ -40,12 +39,6 @@ module Verdict
 
       def scope_key(scope)
         "#{@key_prefix}#{scope}"
-      end
-
-      def move_to_temp(scope)
-        "temp:#{SecureRandom.uuid}".tap do |temp_scope|
-          redis.rename(scope_key(scope), scope_key(temp_scope))
-        end
       end
 
       def clear(scope, cursor: 0)

--- a/test/storage/redis_storage_test.rb
+++ b/test/storage/redis_storage_test.rb
@@ -72,7 +72,6 @@ class RedisStorageTest < Minitest::Test
   end
 
   def test_cleanup
-    SecureRandom.expects(:uuid).returns("uuid")
     1000.times do |n|
       @experiment.assign("something_#{n}")
     end
@@ -81,16 +80,11 @@ class RedisStorageTest < Minitest::Test
 
     @storage.cleanup(:redis_storage)
     refute_operator @redis, :exists, experiment_key
-    refute_operator @redis, :exists, temp_experiment_key
   end
 
   private
 
   def experiment_key
     "experiments/redis_storage"
-  end
-
-  def temp_experiment_key
-    "experiments/temp:uuid"
   end
 end


### PR DESCRIPTION
This was added to the [previous PR](https://github.com/Shopify/verdict/pull/48) after talking with @shivnagarajan, but it doesn't play well with our distributed redis infrastructure.