### PR TITLE
Storage API - make public API more consistent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Next version
+## Unreleased
 
 * Changed `Experiment#cleanup` to accept an argument of type `Verdict::Experiment`.       
   Passing a `String`/`Symbol` argument is still supported, but will log a deprecation warning.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Next version
+
+* Changed `Experiment#cleanup` to accept an argument of type `Verdict::Experiment`.       
+  Passing a `String`/`Symbol` argument is still supported, but will log a deprecation warning.
+
 ## v0.11.0
 
 * Automatic eager loading when inside a Rails app.

--- a/lib/verdict/storage/base_storage.rb
+++ b/lib/verdict/storage/base_storage.rb
@@ -45,11 +45,21 @@ module Verdict
         set(experiment.handle.to_s, 'started_at', timestamp.utc.strftime('%FT%TZ'))
       end
 
-      def cleanup(_scope)
-        raise NotImplementedError
+      # Deletes all assignments (and any other stored data) for the given experiment
+      def cleanup(experiment_or_scope)
+        if experiment_or_scope.is_a?(Symbol) || experiment_or_scope.is_a?(String)
+          Verdict.default_logger.warn(
+            "Passing a scope string/symbol to #{self.class}#cleanup is deprecated, " \
+            'pass a Verdict::Experiment instance instead.'
+          )
+          clear(experiment_or_scope)
+        else
+          clear(experiment_or_scope.handle.to_s)
+        end
       end
 
       protected
+
       # Retrieves a key in a given scope from storage.
       # - The scope and key are both provided as string.
       # - Should return a string value if the key is found in the scope, nil otherwise.
@@ -58,7 +68,7 @@ module Verdict
         raise NotImplementedError
       end
 
-      # Retrieves a key in a given scope from storage.
+      # Sets the value of a key in a given scope from storage.
       # - The scope, key, and value are all provided as string.
       # - Should return true if the item was successfully stored.
       # - Should raise Verdict::StorageError if anything goes wrong.
@@ -66,11 +76,19 @@ module Verdict
         raise NotImplementedError
       end
 
-      # Retrieves a key in a given scope from storage.
+      # Removes a key in a given scope from storage.
       # - The scope and key are both provided as string.
       # - Should return true if the item was successfully removed from storage.
       # - Should raise Verdict::StorageError if anything goes wrong.
       def remove(scope, key)
+        raise NotImplementedError
+      end
+
+      # Removes all keys in a given scope from storage.
+      # - The scope is provided as string.
+      # - Should return true if all items were successfully removed from storage.
+      # - Should raise Verdict::StorageError if anything goes wrong.
+      def clear(scope)
         raise NotImplementedError
       end
     end

--- a/lib/verdict/storage/redis_storage.rb
+++ b/lib/verdict/storage/redis_storage.rb
@@ -28,8 +28,8 @@ module Verdict
         raise Verdict::StorageError, "Redis error: #{e.message}"
       end
 
-      def cleanup(scope)
-        clear(scope)
+      def clear(scope)
+        scrub(scope)
         redis.del(scope_key(scope))
       rescue ::Redis::BaseError => e
         raise Verdict::StorageError, "Redis error: #{e.message}"
@@ -41,12 +41,12 @@ module Verdict
         "#{@key_prefix}#{scope}"
       end
 
-      def clear(scope, cursor: 0)
+      def scrub(scope, cursor: 0)
         cursor, results = redis.hscan(scope_key(scope), cursor, count: PAGE_SIZE)
         results.map(&:first).each do |key|
           remove(scope, key)
         end
-        clear(scope, cursor: cursor) unless cursor.to_i.zero?
+        scrub(scope, cursor: cursor) unless cursor.to_i.zero?
       end
     end
   end

--- a/test/storage/redis_storage_test.rb
+++ b/test/storage/redis_storage_test.rb
@@ -71,6 +71,18 @@ class RedisStorageTest < Minitest::Test
     assert_equal a, @experiment.started_at
   end
 
+  def test_cleanup_with_scope_argument
+    1000.times do |n|
+      @experiment.assign("something_#{n}")
+    end
+
+    assert_operator @redis, :exists, experiment_key
+
+    Verdict.default_logger.expects(:warn).with(regexp_matches(/deprecated/))
+    @storage.cleanup(:redis_storage)
+    refute_operator @redis, :exists, experiment_key
+  end
+
   def test_cleanup
     1000.times do |n|
       @experiment.assign("something_#{n}")
@@ -78,7 +90,7 @@ class RedisStorageTest < Minitest::Test
 
     assert_operator @redis, :exists, experiment_key
 
-    @storage.cleanup(:redis_storage)
+    @storage.cleanup(@experiment)
     refute_operator @redis, :exists, experiment_key
   end
 


### PR DESCRIPTION
This PR build up on the work that was done in #48 - Change `#cleanup` to take an `experiment`, instead of a `scope`.

This is more consistent with the rest of API (public methods deal with experiments, protected methods deal with scopes and keys).

Also, updated some comments that were probably overlooked when copy-pasted.