### PR TITLE
Add CookieStorage backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ test/tmp
 test/version_tmp
 tmp
 dump.rdb
+log

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
+## Unreleased
+
+* Add `CookieStorage` storage backend. This backend is a distributed store for Verdict and does not support experiment timestamps. It is designed to be used with Rails applications and requires that `.cookies` be set to the `CookieJar` instance before use.
+
 ## v0.12.0
 
 * Allow options to be passed to `Experiment#cleanup` so they can be forwarded to storage.
 
-* Changed `Experiment#cleanup` to accept an argument of type `Verdict::Experiment`.       
+* Changed `Experiment#cleanup` to accept an argument of type `Verdict::Experiment`.
   Passing a `String`/`Symbol` argument is still supported, but will log a deprecation warning.
 
 ## v0.11.0

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Verdict uses a very simple interface for storing experiment assignments. Out of 
 
 * Memory
 * Redis
+* Cookies
 
 You can set up storage for your experiment by calling the `storage` method with
 an object that responds to the following methods:
@@ -94,7 +95,7 @@ When removing old experiments you might want to clean up corresponding experimen
 By using the logger, this data removal doesn't impact historic data or data analysis.
 
 
-For more details about these methods, check out the source code for [Verdict::Storage::MockStorage](lib/verdict/storage/mock_storage.rb)
+For more details about these methods, check out the source code for [`Verdict::Storage::MockStorage`](lib/verdict/storage/mock_storage.rb)
 
 ## Logging
 

--- a/lib/verdict/experiment.rb
+++ b/lib/verdict/experiment.rb
@@ -239,10 +239,12 @@ class Verdict::Experiment
   def set_start_timestamp
     @storage.store_start_timestamp(self, started_now = Time.now.utc)
     started_now
+  rescue NotImplementedError
+    nil
   end
 
   def ensure_experiment_has_started
-    @started_at ||= @storage.retrieve_start_timestamp(self) || set_start_timestamp
+    @started_at ||= started_at || set_start_timestamp
   rescue Verdict::StorageError
     @started_at ||= Time.now.utc
   end

--- a/lib/verdict/storage.rb
+++ b/lib/verdict/storage.rb
@@ -1,4 +1,5 @@
 require 'verdict/storage/base_storage'
+require 'verdict/storage/cookie_storage'
 require 'verdict/storage/mock_storage'
 require 'verdict/storage/memory_storage'
 require 'verdict/storage/redis_storage'

--- a/lib/verdict/storage/cookie_storage.rb
+++ b/lib/verdict/storage/cookie_storage.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+module Verdict
+  module Storage
+    # CookieStorage, unlike other Verdict storage classes, is distributed and stored on the client.
+    # Because cookies are opaque to users, we obsfucate information about the test such as the
+    # human readable names for the experiment or assignment group. This means this class assumes
+    # that `name` will be an obsfucated value, or one that we comfortable being "public".
+    class CookieStorage < BaseStorage
+      DEFAULT_COOKIE_LIFESPAN_SECONDS = 15778476 # 6 months
+
+      attr_accessor :cookies
+      attr_reader :cookie_lifespan
+
+      def initialize(options = {})
+        @cookies = options[:cookies] || {}
+        @cookie_lifespan = options[:cookie_lifespan] || DEFAULT_COOKIE_LIFESPAN_SECONDS
+      end
+
+      def store_assignment(assignment)
+        hash = { group: assignment.group.name, created_at: assignment.created_at.strftime('%FT%TZ') }
+        set("verdict_#{assignment.experiment.name}", nil, JSON.dump(hash))
+      end
+
+      def retrieve_assignment(experiment, subject)
+        if (value = get("verdict_#{experiment.name}", nil))
+          hash = parse_cookie_value(value)
+          group = experiment.groups.values.find { |g| g.name == hash['group'] }
+
+          if group.nil?
+            experiment.remove_subject_assignment(subject)
+            return nil
+          end
+
+          experiment.subject_assignment(subject, group, Time.xmlschema(hash['created_at']))
+        end
+      end
+
+      def remove_assignment(experiment, _subject)
+        remove("verdict_#{experiment.name}", nil)
+      end
+
+      def retrieve_start_timestamp(_experiment)
+        nil
+      end
+
+      def store_start_timestamp(_experiment, _timestamp)
+        true
+      end
+
+      protected
+
+      def get(scope, _key)
+        cookies[scope]
+      end
+
+      def set(scope, _key, value)
+        cookies[scope] = {
+          value: value,
+          expires: Time.now.utc.advance(seconds: cookie_lifespan),
+        }
+      end
+
+      def remove(scope, _key)
+        cookies.delete(scope)
+      end
+
+      private
+
+      def parse_cookie_value(value)
+        value = value[:value] if value.is_a?(Hash)
+
+        JSON.parse(value)
+      rescue
+        {}
+      end
+    end
+  end
+end

--- a/lib/verdict/storage/cookie_storage.rb
+++ b/lib/verdict/storage/cookie_storage.rb
@@ -45,7 +45,7 @@ module Verdict
       end
 
       def store_start_timestamp(_experiment, _timestamp)
-        true
+        raise NotImplementedError
       end
 
       protected

--- a/lib/verdict/storage/cookie_storage.rb
+++ b/lib/verdict/storage/cookie_storage.rb
@@ -93,7 +93,7 @@ module Verdict
         value = value[:value] if value.is_a?(Hash)
 
         JSON.parse(value)
-      rescue
+      rescue JSON::ParserError, TypeError
         {}
       end
 

--- a/lib/verdict/storage/cookie_storage.rb
+++ b/lib/verdict/storage/cookie_storage.rb
@@ -12,9 +12,9 @@ module Verdict
       attr_accessor :cookies
       attr_reader :cookie_lifespan
 
-      def initialize(options = {})
-        @cookies = options[:cookies] || {}
-        @cookie_lifespan = options[:cookie_lifespan] || DEFAULT_COOKIE_LIFESPAN_SECONDS
+      def initialize(cookies: {}, cookie_lifespan: DEFAULT_COOKIE_LIFESPAN_SECONDS)
+        @cookies = cookies
+        @cookie_lifespan = cookie_lifespan
       end
 
       def store_assignment(assignment)

--- a/lib/verdict/storage/cookie_storage.rb
+++ b/lib/verdict/storage/cookie_storage.rb
@@ -13,8 +13,8 @@ module Verdict
       attr_accessor :cookies
       attr_reader :cookie_lifespan
 
-      def initialize(cookies: {}, cookie_lifespan: DEFAULT_COOKIE_LIFESPAN_SECONDS)
-        @cookies = cookies
+      def initialize(cookie_lifespan: DEFAULT_COOKIE_LIFESPAN_SECONDS)
+        @cookies = nil
         @cookie_lifespan = cookie_lifespan
       end
 
@@ -56,10 +56,12 @@ module Verdict
       protected
 
       def get(scope, key)
+        ensure_cookies_is_set
         cookies[scope_key(scope, key)]
       end
 
       def set(scope, key, value)
+        ensure_cookies_is_set
         cookies[scope_key(scope, key)] = {
           value: value,
           expires: Time.now.utc.advance(seconds: cookie_lifespan),
@@ -67,10 +69,15 @@ module Verdict
       end
 
       def remove(scope, key)
+        ensure_cookies_is_set
         cookies.delete(scope_key(scope, key))
       end
 
       private
+
+      def ensure_cookies_is_set
+        raise Verdict::StorageError, 'cookies must be an instance of ActionDispatch::Cookies::CookieJar' if cookies.nil?
+      end
 
       def digest_of(value)
         Digest::MD5.hexdigest(value)

--- a/test/experiment_test.rb
+++ b/test/experiment_test.rb
@@ -414,6 +414,16 @@ class ExperimentTest < Minitest::Test
     assert e.started?, "The experiment should have started after the first assignment"
   end
 
+  def test_experiment_set_start_timestamp_handles_storage_that_does_not_implement_timestamps
+    e = Verdict::Experiment.new('starting_test') do
+      groups { group :all, 100 }
+    end
+
+    e.storage.expects(:store_start_timestamp).raises(NotImplementedError)
+
+    assert_nil e.send(:set_start_timestamp)
+  end
+
   def test_no_storage
     e = Verdict::Experiment.new('starting_test') do
       groups { group :all, 100 }

--- a/test/storage/cookie_storage_test.rb
+++ b/test/storage/cookie_storage_test.rb
@@ -18,7 +18,9 @@ class CookieStorageTest < Minitest::Test
   end
 
   def test_cookie_lifespan_has_a_default
-    refute_nil Verdict::Storage::CookieStorage.new.cookie_lifespan
+    cookie_lifespan = Verdict::Storage::CookieStorage.new.cookie_lifespan
+
+    assert_equal Verdict::Storage::CookieStorage::DEFAULT_COOKIE_LIFESPAN_SECONDS, cookie_lifespan
   end
 
   def test_cookie_lifespan_can_be_configured

--- a/test/storage/cookie_storage_test.rb
+++ b/test/storage/cookie_storage_test.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class CookieStorageTest < Minitest::Test
+  def setup
+    @storage = storage = Verdict::Storage::CookieStorage.new
+    @experiment = Verdict::Experiment.new(:cookie_storage_test) do
+      name 1234
+      groups do
+        group :all, 100 do name 5678
+        end
+      end
+      storage storage, store_unqualified: true
+    end
+    @subject = stub(id: 'bob')
+    @assignment = Verdict::Assignment.new(@experiment, @subject, @experiment.group(:all), nil)
+  end
+
+  def test_cookie_lifespan_has_a_default
+    refute_nil Verdict::Storage::CookieStorage.new.cookie_lifespan
+  end
+
+  def test_cookie_lifespan_can_be_configured
+    storage = Verdict::Storage::CookieStorage.new(cookie_lifespan: 60)
+
+    assert_equal 60, storage.cookie_lifespan
+  end
+
+  def test_store_assignment_returns_true_when_an_assignment_is_stored
+    assert @storage.store_assignment(@assignment)
+  end
+
+  def test_retrieve_assignment_returns_an_assignment
+    @storage.store_assignment(@assignment)
+    assignment = @storage.retrieve_assignment(@experiment, @subject)
+
+    assert assignment.returning?
+    assert_equal :all, assignment.handle.to_sym
+    assert_equal @experiment, assignment.experiment
+    assert_equal @subject, assignment.subject
+  end
+
+  def test_retrieve_assignment_returns_nil_when_an_assignment_does_not_exist
+    assert_nil @storage.retrieve_assignment(@experiment, @subject)
+  end
+
+  def test_retrieve_assignment_returns_nil_when_the_assignment_group_is_invalid
+    invalid_group = Verdict::Group.new(@experiment, :invalid)
+    invalid_group.name('invalid')
+    assignment = Verdict::Assignment.new(@experiment, @subject, invalid_group, nil)
+
+    @storage.store_assignment(assignment)
+
+    assert_nil @storage.retrieve_assignment(@experiment, @subject)
+  end
+
+  def test_remove_assignment_returns_true_when_removing_an_assignment
+    @storage.store_assignment(@assignment)
+
+    assert @storage.remove_assignment(@experiment, nil)
+    assert_nil @storage.retrieve_assignment(@experiment, @subject)
+  end
+
+  def test_retrieve_start_timestamp_always_returns_nil
+    assert_nil @storage.retrieve_start_timestamp(nil)
+  end
+
+  def test_store_start_timestamp_always_returns_true
+    assert @storage.store_start_timestamp(nil, nil)
+  end
+end

--- a/test/storage/cookie_storage_test.rb
+++ b/test/storage/cookie_storage_test.rb
@@ -6,11 +6,7 @@ class CookieStorageTest < Minitest::Test
   def setup
     @storage = storage = Verdict::Storage::CookieStorage.new
     @experiment = Verdict::Experiment.new(:cookie_storage_test) do
-      name 1234
-      groups do
-        group :all, 100 do name 5678
-        end
-      end
+      groups { group :all, 100 }
       storage storage, store_unqualified: true
     end
     @subject = stub(id: 'bob')
@@ -49,7 +45,6 @@ class CookieStorageTest < Minitest::Test
 
   def test_retrieve_assignment_returns_nil_when_the_assignment_group_is_invalid
     invalid_group = Verdict::Group.new(@experiment, :invalid)
-    invalid_group.name('invalid')
     assignment = Verdict::Assignment.new(@experiment, @subject, invalid_group, nil)
 
     @storage.store_assignment(assignment)

--- a/test/storage/cookie_storage_test.rb
+++ b/test/storage/cookie_storage_test.rb
@@ -68,7 +68,7 @@ class CookieStorageTest < Minitest::Test
     assert_nil @storage.retrieve_start_timestamp(nil)
   end
 
-  def test_store_start_timestamp_always_returns_true
-    assert @storage.store_start_timestamp(nil, nil)
+  def test_store_start_timestamp_raises_not_implemented_error
+    assert_raises(NotImplementedError) { @storage.store_start_timestamp(nil, nil) }
   end
 end

--- a/test/storage/cookie_storage_test.rb
+++ b/test/storage/cookie_storage_test.rb
@@ -38,6 +38,7 @@ class CookieStorageTest < Minitest::Test
 
   def test_store_assignment_returns_true_when_an_assignment_is_stored
     assert @storage.store_assignment(@assignment)
+    refute_nil @storage.retrieve_assignment(@experiment, @subject)
   end
 
   def test_retrieve_assignment_returns_an_assignment


### PR DESCRIPTION
This PR adds a `CookieStorage` backend, which enables Verdict to store experiment assignments in cookies. 

For the most part this is straightforward with a few things worth highlighting:

- It's expected that applications override `storage.cookies` to an instance of [`ActionDispatch::Cookies`](https://api.rubyonrails.org/v5.2.3/classes/ActionDispatch/Cookies.html). By default the backend is very similar to `MemoryStorage` in that assignments are stored in a hash. It's only when the AD:C (or interfaces that mirror it) is plugged in that cookies are actually set to the browser.
- It introduces a convention that the `name` of experiments/groups is a value that we are happy with a client knowing. Experiments and Group both inherit `Verdict::Metadata` which has this property, but it's a not a requirement of experiments to set it.