### PR TITLE
Automatically eager load when inside a Rails app

### DIFF
--- a/lib/verdict.rb
+++ b/lib/verdict.rb
@@ -15,6 +15,10 @@ module Verdict
     @repository
   end
 
+  def eager_load!
+    discovery
+  end
+
   def discovery
     @repository = {}
     Dir[File.join(Verdict.directory, '**', '*.rb')].each { |f| load f } if @directory

--- a/lib/verdict/railtie.rb
+++ b/lib/verdict/railtie.rb
@@ -1,5 +1,7 @@
 class Verdict::Railtie < Rails::Railtie
   initializer "experiments.configure_rails_initialization" do |app|
+    app.config.eager_load_namespaces << Verdict
+
     Verdict.default_logger = Rails.logger
 
     Verdict.directory ||= Rails.root.join('app', 'experiments')


### PR DESCRIPTION
In core [we call `Verdict.discovery` on boot](https://github.com/Shopify/shopify/blob/261c95e8c24438d0ab8f3bbd4ab1d2cff74ea56d/config/application.rb#L299) because it's a slow operation so we want it to happen during boot rather than of the first request.

The proper pattern for this is to define a `Namespace.eager_load!` method and append `Namespace` into `app.config.eager_load_namespace`.

This way users won't have to know about this, it will happen automatically.