### PR TITLE
Update Experiment#cleanup

### DIFF
--- a/lib/verdict/experiment.rb
+++ b/lib/verdict/experiment.rb
@@ -163,7 +163,7 @@ class Verdict::Experiment
   end
 
   def cleanup
-    @storage.cleanup(handle.to_s)
+    @storage.cleanup(self)
   end
 
   def remove_subject_assignment(subject)


### PR DESCRIPTION
Following up on #50 

In `Experiment#cleanup`, pass an `Experiment` object to `@storage#cleanup` (instead of passing the handle).