### PR TITLE
Add rationale for why storage shouldn't be used for analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,11 @@ By default it will use `subject.id.to_s` as `subject_identifier`, but you can ch
 
 Storage providers simply store subject assignments and require quick lookups of subject identifiers. They allow for complex (high CPU) assignments, and for assignments that might not always put the same subject in the same group by storing the assignment for later use.
 
-Storage providers are intended for operational use and should not be used for data analysis. For data analysis, you should use the logger.
+Storage providers are intended for operational use and should not be used for data analysis.
+For data analysis, you should use the logger.
+When removing old experiments you might want to clean up corresponding experiment assignments, to reduce the amount of data stored and loaded.
+By using the logger, this data removal doesn't impact historic data or data analysis.
+
 
 For more details about these methods, check out the source code for [Verdict::Storage::MockStorage](lib/verdict/storage/mock_storage.rb)
 


### PR DESCRIPTION
I was exploring extracting the experiment assignments storage to use for data analysis, but then after thinking some more (and reading the README), I realized there are good reasons to separate the operational and analytical data stores. I updated the README to expand on that rationale a bit.