### PR TITLE
Add concepts documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,4 +4,4 @@
 2. Create your feature branch (`git checkout -b my-new-feature`)
 3. Commit your changes, including tests (`git commit -am 'Added some feature'`)
 4. Push to the branch (`git push origin my-new-feature`)
-5. Create new Pull Request, and mention @wvanbergen.
+5. Create new Pull Request

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,7 @@
+## Contributing
+
+1. Fork it
+2. Create your feature branch (`git checkout -b my-new-feature`)
+3. Commit your changes, including tests (`git commit -am 'Added some feature'`)
+4. Push to the branch (`git push origin my-new-feature`)
+5. Create new Pull Request, and mention @wvanbergen.

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ Add this line to your application's Gemfile, and run `bundle install`:
 
 If you're using Rails, the Railtie will handle setting the logger to `Rails.logger` and the experiments directory to `app/experiments`. It will also load the rake tasks for you (run `bundle exec rake -T | grep experiments:` for options).
 
+You may find the [Concepts](docs/concepts.md) documentation a good place to familiarise yourself with Verdict's nomenclature.
+
 ## Usage
 
 The `Verdict::Experiment` class is used to create an experiment, define control and experiment groups, and to qualify subjects.
@@ -42,8 +44,7 @@ Verdict::Experiment.define :my_experiment do
 end
 ```
 
-Usually you'll want to place this in a file called **my_experiment.rb** in the
-**/app/experiments** folder.
+Usually you'll want to place this in a file called **my_experiment.rb** in the **/app/experiments** folder.
 
 _We recommend that you subclass `Verdict::Experiment` to set some default options for your app's environment, and call `define` on that class instead._
 
@@ -73,8 +74,7 @@ Verdict uses a very simple interface for storing experiment assignments. Out of 
 * Redis
 * Cookies
 
-You can set up storage for your experiment by calling the `storage` method with
-an object that responds to the following methods:
+You can set up storage for your experiment by calling the `storage` method with an object that responds to the following methods:
 
 * `store_assignment(assignment)`
 * `retrieve_assignment(experiment, subject)`
@@ -84,16 +84,13 @@ an object that responds to the following methods:
 
 Regarding the method signatures above, `experiment` is the Experiment instance, `subject` is the Subject instance, and `assignment` is a `Verdict::Assignment` instance.
 
-The `subject` instance will be identified internally by its `subject_identifier`
-By default it will use `subject.id.to_s` as `subject_identifier`, but you can change that by overriding `def subject_identifier(subject)` on the experiment.
+The `subject` instance will be identified internally by its `subject_identifier`. By default it will use `subject.id.to_s` as `subject_identifier`, but you can change that by overriding `def subject_identifier(subject)` on the experiment.
 
 Storage providers simply store subject assignments and require quick lookups of subject identifiers. They allow for complex (high CPU) assignments, and for assignments that might not always put the same subject in the same group by storing the assignment for later use.
 
-Storage providers are intended for operational use and should not be used for data analysis.
-For data analysis, you should use the logger.
-When removing old experiments you might want to clean up corresponding experiment assignments, to reduce the amount of data stored and loaded.
-By using the logger, this data removal doesn't impact historic data or data analysis.
+Storage providers are intended for operational use and should not be used for data analysis. For data analysis, you should use [the logger](#logging).
 
+When removing old experiments you might want to clean up corresponding experiment assignments, to reduce the amount of data stored and loaded. By using the logger, this data removal doesn't impact historic data or data analysis.
 
 For more details about these methods, check out the source code for [`Verdict::Storage::MockStorage`](lib/verdict/storage/mock_storage.rb)
 
@@ -106,12 +103,3 @@ You can override the logging by overriding the `def log_assignment(assignment)` 
 Logging (as opposed to storage) should be used for data analysis. The logger requires a write-only / forward-only stream to write to, e.g. a log file, Kafka, or an insert-only database table.
 
 It's possible to run an experiment without defining any storage, though this comes with several drawbacks. Logging on the other hand is required in order to analyze the results.
-
-
-## Contributing
-
-1. Fork it
-2. Create your feature branch (`git checkout -b my-new-feature`)
-3. Commit your changes, including tests (`git commit -am 'Added some feature'`)
-4. Push to the branch (`git push origin my-new-feature`)
-5. Create new Pull Request, and mention @wvanbergen.

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -1,6 +1,6 @@
 # Verdict Concepts
 
-Understanding the following Verdict concepts can help implement experiments and discuss them with peers.
+Understanding the following Verdict concepts can help you implement experiments and discuss them with peers.
 
 - [Experiment](#experiment)
 - [Qualifiers](#qualifiers)
@@ -14,12 +14,13 @@ Understanding the following Verdict concepts can help implement experiments and 
 
 ### Qualifers
 
-Qualifiers are methods that take two parameters, `subject` and `context` and returns `true` if the `subject` can take this experiment, or `false` if the `subject` is not eligible. Experiments can have multiple qualifiers which are evaluated in succession. If a qualifier returns `false` no further qualifiers are checked.
+Qualifiers are methods that take two parameters, `subject` and `context`. They return `true` if the `subject` can take this experiment, or `false` if the `subject` is not eligible. Experiments can have multiple qualifiers which are evaluated in succession. If a qualifier returns `false`, no further qualifiers are checked.
 
-Examples of qualifiers might be:
+Examples of qualifiers might be subjects that:
 
-- Include subjects that originate from SpeedCurve or WebPage Test
-- Include subjects that have added items to their cart.
+- Originate from certain browsers or devices
+- Have a specific `Accept-Language` header
+- Have added items to their cart.
 
 ### Subject
 

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -1,0 +1,34 @@
+# Verdict Concepts
+
+Understanding the following Verdict concepts can help implement experiments and discuss them with peers.
+
+- [Experiment](#experiment)
+- [Qualifiers](#qualifiers)
+- [Subject](#subject)
+- [Group](#group)
+- [Assignment](#assignment)
+
+### Experiment
+
+`Experiment`s are defined in `app/experiments` and encapsulate the details of the test including metadata such as the name, description or owners, as well as any [qualifiers](#qualifiers) or the [groups](#groups) available in the test.
+
+### Qualifers
+
+Qualifiers are methods that take two parameters, `subject` and `context` and returns `true` if the `subject` can take this experiment, or `false` if the `subject` is not eligible. Experiments can have multiple qualifiers which are evaluated in succession. If a qualifier returns `false` no further qualifiers are checked.
+
+Examples of qualifiers might be:
+
+- Include subjects that originate from SpeedCurve or WebPage Test
+- Include subjects that have added items to their cart.
+
+### Subject
+
+A subject is the thing that will be [qualified](#qualifiers), and if successfull, [assigned](#assignment) to a particular [group](#group). For example, a subject might represent a user.
+
+### Group
+
+Each [experiment](#experiment) will have two or more groups, usually a control group and a test group. Qualified [subjects](#subject) are assigned to one of the groups in the experiment.
+
+### Assignment
+
+An assignment occurs when a qualified [subject](#subject) is placed into a [group](#group). Assignments are persisted so repeat visits by the subject skip [qualification](#qualifiers) and re-assignment and simply returns the existing assignment.


### PR DESCRIPTION
When using this gem for the first time, my team and I struggled to learn the concepts that were involved, especially as we were coming from a "homegrown" solution to A/B testing that didn't use these terms.

To help, I wrote some concept documentation in our project. I thought I'd offer to backport it to the gem considering it's open-source and there may be others that would benefit.

If I've misunderstood anything, or things are wrong, please let me know!

