### PR TITLE
Support Zeitwerk autoloading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+* Support eager loading from within a Rails app using Zeitwerk.
 * Add `CookieStorage` storage backend. This backend is a distributed store for Verdict and does not support experiment timestamps. It is designed to be used with Rails applications and requires that `.cookies` be set to the `CookieJar` instance before use.
 
 ## v0.12.0

--- a/lib/verdict/railtie.rb
+++ b/lib/verdict/railtie.rb
@@ -5,10 +5,15 @@ class Verdict::Railtie < Rails::Railtie
     Verdict.default_logger = Rails.logger
 
     Verdict.directory ||= Rails.root.join('app', 'experiments')
-    app.config.eager_load_paths -= Dir[Verdict.directory.to_s]
 
-    # Re-freeze eager load paths to ensure they blow up if modified at runtime, as Rails does
-    app.config.eager_load_paths.freeze
+    if Rails.gem_version >= Gem::Version.new('6.0.0') && Rails.autoloaders.zeitwerk_enabled?
+      Rails.autoloaders.main.ignore(Verdict.directory)
+    else
+      app.config.eager_load_paths -= Dir[Verdict.directory.to_s]
+
+      # Re-freeze eager load paths to ensure they blow up if modified at runtime, as Rails does
+      app.config.eager_load_paths.freeze
+    end
   end
 
   config.to_prepare do


### PR DESCRIPTION
Fixes #59 

### Why

Before the gem experiments directory was loaded twice (once by the Gem, once by Zeitwerk), raising an error

### How

* We use the new `config.autoloader` method to detect what is the rails autoloader.
* Then we configure Zeitwerk to ignore the experiments folder,

### Edge cases

* We safeguard against rails configuration for version older than 6 which didn't had autoloader method.

PS : I didn't bump the gem version, since I'm not an owner.