### PR TITLE
Support experiment scheduling time constraint

### DIFF
--- a/lib/verdict/experiment.rb
+++ b/lib/verdict/experiment.rb
@@ -52,6 +52,17 @@ class Verdict::Experiment
     return self
   end
 
+  # Optional: Together with the "end timestamp", limits the experiment run timeline within
+  # the given time interval. When experiment is not scheduled, subject switch returns nil.
+  # This is useful when the experimenter requires the experiment to run in a strict timeline.
+  def schedule_start_timestamp(timestamp)
+    @schedule_start_timestamp = timestamp
+  end
+
+  def schedule_end_timestamp(timestamp)
+    @schedule_end_timestamp = timestamp
+  end
+
   def rollout_percentage(percentage, rollout_group_name = :enabled)
     groups(Verdict::Segmenters::RolloutSegmenter) do
       group rollout_group_name, percentage
@@ -172,6 +183,7 @@ class Verdict::Experiment
   end
 
   def switch(subject, context = nil)
+    return unless is_scheduled?
     assign(subject, context).to_sym
   end
 
@@ -251,5 +263,17 @@ class Verdict::Experiment
 
   def nil_assignment(subject)
     subject_assignment(subject, nil, nil)
+  end
+
+  private
+
+  def is_scheduled?
+    if @schedule_start_timestamp and @schedule_start_timestamp > Time.now
+      return false
+    end
+    if @schedule_end_timestamp and @schedule_end_timestamp < Time.now
+      return false
+    end
+    return true
   end
 end


### PR DESCRIPTION
**Background**

We want to support time scheduling in Verdict to enable strict control over **when** the experiment is running. This is important, for instance, to avoid the "different day" bias that arise when an experiment is not stopped at a desired, pre-planned time.

Closes https://github.com/Shopify/verdict/issues/63.

**Changes**

- New (optional) `schedule_start_timestamp` and `schedule_end_timestamp` methods in the Experiment definition. These are used to limit experiment's timeline. It is possible to one, both, or neither of these methods when defining an experiment.
- Call `is_scheduled?` every time, in `switch`, before calling `assign`, to make sure that the experiment is scheduled.
- Unit tests.

@Shopify/experiments 