### PR TITLE
Allow jruby job to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,5 +11,6 @@ rvm:
 matrix:
   allow_failures:
     - rvm: ruby-head
+    - rvm: jruby
 services:
   - redis-server


### PR DESCRIPTION
I have triggered a master build at https://travis-ci.org/github/Shopify/verdict/builds/669739330, which is failing because the jruby job is failing. For now, let's allow this job to tail to not block PRs. Later on, we can decide whether to remove the job entirely.

@Shopify/experiments 