### PR TITLE
Prepare for 0.13.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
-## Unreleased
+## v0.13.0
 
+* Add optional experiment definition methods `schedule_start_timestamp` and `schedule_end_timestamp` to support limiting experiment's lifetime in a pre-determined time interval.
 * Support eager loading from within a Rails app using Zeitwerk.
 * Add `CookieStorage` storage backend. This backend is a distributed store for Verdict and does not support experiment timestamps. It is designed to be used with Rails applications and requires that `.cookies` be set to the `CookieJar` instance before use.
 

--- a/lib/verdict/version.rb
+++ b/lib/verdict/version.rb
@@ -1,3 +1,3 @@
 module Verdict
-  VERSION = "0.12.0"
+  VERSION = "0.13.0"
 end


### PR DESCRIPTION
Similar to https://github.com/Shopify/verdict/commit/60682ac9b683cc93f2d614b9e93d94bbe2f05487, I've updated the changelog and the version so we can proceed with a release.