### PR TITLE
Add allowed_push_host to gemspec

### DIFF
--- a/verdict.gemspec
+++ b/verdict.gemspec
@@ -17,6 +17,8 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
+  gem.metadata["allowed_push_host"] = "https://rubygems.org"
+
   gem.add_development_dependency("minitest", '~> 5.2')
   gem.add_development_dependency("rake")
   gem.add_development_dependency("mocha")


### PR DESCRIPTION
Shipit is failing because the gemspec is missing `allowed_push_host`.

> Can't release the gem: spec.metadata['allowed_push_host'] must be defined.

This PR assigns `allowed_push_host` to rubygems (i.e. the only host we are pushing to).