### PR TITLE
Add schedule stop new assignment timestamp

### DIFF
--- a/lib/verdict/experiment.rb
+++ b/lib/verdict/experiment.rb
@@ -55,10 +55,11 @@ class Verdict::Experiment
   # Optional: Together with the "end_timestamp" and "stop_new_assignment_timestamp", limits the experiment run timeline within
   # the given time interval.
   #
-  # Timestamps' definitions:
-  # start_timestamp: Experiment's start time. No assignments are made and switch will return nil before this timestamp
-  # stop_new_assignment_timestamp: Experiment's new assignment stop time. No new assignments are made and switch returns nil for new assignments after timestamp
-  # end_timestamp: Experiment's end time. No assignments are made and switch returns nil after this timestamp
+  # Timestamps definitions:
+  # start_timestamp: Experiment's start time. No assignments are made i.e. switch will return nil before this timestamp.
+  # stop_new_assignment_timestamp: Experiment's new assignment stop time. No new assignments are made
+  # i.e. switch returns nil for new assignments but the existing assignments are preserved.
+  # end_timestamp: Experiment's end time. No assignments are made i.e. switch returns nil after this timestamp.
   #
   # Experiment run timeline:
   # start_timestamp -> (new assignments occur) -> stop_new_assignment_timestamp -> (no new assignments occur) -> end_timestamp
@@ -147,7 +148,7 @@ class Verdict::Experiment
     subject_identifier = retrieve_subject_identifier(subject)
     assignment = if previous_assignment
                    previous_assignment
-                 elsif subject_qualifies?(subject, context) && (not is_stop_new_assignments?)
+                 elsif subject_qualifies?(subject, context) && is_make_new_assignments?
                    group = segmenter.assign(subject_identifier, subject, context)
                    subject_assignment(subject, group, nil, group.nil?)
                  else
@@ -279,16 +280,16 @@ class Verdict::Experiment
   private
 
   def is_scheduled?
-    if @schedule_start_timestamp and @schedule_start_timestamp > Time.now
+    if @schedule_start_timestamp && @schedule_start_timestamp > Time.now
       return false
     end
-    if @schedule_end_timestamp and @schedule_end_timestamp < Time.now
+    if @schedule_end_timestamp && @schedule_end_timestamp < Time.now
       return false
     end
     return true
   end
 
-  def is_stop_new_assignments?
-    return @schedule_stop_new_assignment_timestamp && @schedule_stop_new_assignment_timestamp < Time.now
+  def is_make_new_assignments?
+    return !(@schedule_stop_new_assignment_timestamp && @schedule_stop_new_assignment_timestamp < Time.now)
   end
 end

--- a/lib/verdict/experiment.rb
+++ b/lib/verdict/experiment.rb
@@ -65,8 +65,9 @@ class Verdict::Experiment
 
   # Optional: Together with start and end timestamp, limits the experiment assignments within
   # an even tighter time interval. When experiment assignment happens after the stop_new_assignment
-  # timestamp, subject switch returns nil. This is useful when experimenter requires the experiment
-  # to have a cool down period with no new assignments to guarantee stable experiment analysis.
+  # timestamp, subject switch returns nil (i.e. start timestamp -> stop assignment timestamp -> end timestamp).
+  # This is useful when experimenter requires the experiment to have a cool down period with
+  # no new assignments to guarantee stable experiment analysis.
   def schedule_stop_new_assignment_timestamp(timestamp)
     @schedule_stop_new_assignment_timestamp = timestamp
   end
@@ -191,7 +192,7 @@ class Verdict::Experiment
   end
 
   def switch(subject, context = nil)
-    return unless is_scheduled? || (not is_stopped_new_assignments?)
+    return unless is_scheduled? && (not is_stop_new_assignments?)
     assign(subject, context).to_sym
   end
 
@@ -285,8 +286,13 @@ class Verdict::Experiment
     return true
   end
 
-  def is_stopped_new_assignments?
-    if @schedule_stop_new_assignment_timestamp and @schedule_stop_new_assignment_timestamp < Time.now
+  def is_stop_new_assignments?
+    if @schedule_stop_new_assignment_timestamp and
+        @schedule_start_timestamp and
+        @schedule_end_timestamp and
+        @schedule_stop_new_assignment_timestamp > @schedule_start_timestamp and
+        @schedule_stop_new_assignment_timestamp < @schedule_end_timestamp and
+        @schedule_stop_new_assignment_timestamp < Time.now
       return true
     end
     return false

--- a/lib/verdict/experiment.rb
+++ b/lib/verdict/experiment.rb
@@ -287,12 +287,7 @@ class Verdict::Experiment
   end
 
   def is_stop_new_assignments?
-    if @schedule_stop_new_assignment_timestamp and
-        @schedule_start_timestamp and
-        @schedule_end_timestamp and
-        @schedule_stop_new_assignment_timestamp > @schedule_start_timestamp and
-        @schedule_stop_new_assignment_timestamp < @schedule_end_timestamp and
-        @schedule_stop_new_assignment_timestamp < Time.now
+    if @schedule_stop_new_assignment_timestamp and @schedule_stop_new_assignment_timestamp < Time.now
       return true
     end
     return false

--- a/test/experiment_test.rb
+++ b/test/experiment_test.rb
@@ -600,7 +600,10 @@ class ExperimentTest < Minitest::Test
     # switch respects to stop new assignment timestamp even after the assignment occurred
     Timecop.freeze(Time.new(2020, 4, 16)) do
       assert e.send(:is_stop_new_assignments?)
-      assert_nil e.switch(1)
+      # old assignment stay the same
+      assert_equal :a, e.switch(1)
+      # new assignment returns nil
+      assert_nil e.switch(2)
     end
   end
 

--- a/test/experiment_test.rb
+++ b/test/experiment_test.rb
@@ -576,16 +576,17 @@ class ExperimentTest < Minitest::Test
 
     # new assignments stopped after the stop timestamp
     Timecop.freeze(Time.new(2020, 1, 16)) do
-      assert e.send(:is_stop_new_assignments?)
+      assert !e.send(:is_make_new_assignments?)
       assert_nil e.switch(1)
     end
     # new assignments didn't stop before the stop timestamp
     Timecop.freeze(Time.new(2020, 1, 3)) do
-      assert !e.send(:is_stop_new_assignments?)
+      assert e.send(:is_make_new_assignments?)
+      assert :a, e.switch(2)
     end
   end
 
-  def test_switch_respects_stop_new_assignment_timestamp_even_after_assignment
+  def test_switch_preserves_old_assignments_after_stop_new_assignments_timestamp
     e = Verdict::Experiment.new('test') do
       groups do
         group :a, :half
@@ -599,7 +600,7 @@ class ExperimentTest < Minitest::Test
 
     # switch respects to stop new assignment timestamp even after the assignment occurred
     Timecop.freeze(Time.new(2020, 4, 16)) do
-      assert e.send(:is_stop_new_assignments?)
+      assert !e.send(:is_make_new_assignments?)
       # old assignment stay the same
       assert_equal :a, e.switch(1)
       # new assignment returns nil

--- a/test/experiment_test.rb
+++ b/test/experiment_test.rb
@@ -565,22 +565,86 @@ class ExperimentTest < Minitest::Test
     end
   end
 
-  def test_is_stopped_new_assignment
+  def test_is_stop_new_assignment
     e = Verdict::Experiment.new('test') do
       groups do
         group :a, :half
         group :b, :half
       end
-      schedule_stop_new_assignment_timestamp Time.new(2020, 1, 1)
+      schedule_start_timestamp Time.new(2020, 1, 1)
+      schedule_stop_new_assignment_timestamp Time.new(2020, 1, 15)
+      schedule_end_timestamp Time.new(2020, 2, 1)
     end
 
     # new assignments stopped after the stop timestamp
-    Timecop.freeze(Time.new(2020, 1, 2)) do
-      assert e.send(:is_stopped_new_assignments?)
+    Timecop.freeze(Time.new(2020, 1, 16)) do
+      assert e.send(:is_stop_new_assignments?)
+      assert_nil e.switch(1)
     end
     # new assignments didn't stop before the stop timestamp
-    Timecop.freeze(Time.new(2019, 12, 30)) do
-      assert !e.send(:is_stopped_new_assignments?)
+    Timecop.freeze(Time.new(2020, 1, 3)) do
+      assert !e.send(:is_stop_new_assignments?)
+    end
+  end
+
+  def test_is_stop_new_assignment_with_no_start_or_end_timestamp
+    e = Verdict::Experiment.new('test') do
+      groups do
+        group :a, :half
+        group :b, :half
+      end
+      schedule_start_timestamp Time.new(2020, 4, 1)
+      schedule_stop_new_assignment_timestamp Time.new(2020, 4, 22)
+    end
+
+    #without end timestamp, assignment will not respect stop new assignment timestamp
+    Timecop.freeze(Time.new(2020, 4, 23)) do
+      assert !e.send(:is_stop_new_assignments?)
+    end
+
+    #with end timestamp, assignment will respect stop new assignment timestamp
+    e.schedule_end_timestamp Time.new(2020, 4, 30)
+    Timecop.freeze(Time.new(2020, 4, 23)) do
+      assert e.send(:is_stop_new_assignments?)
+      assert_nil e.switch(1)
+    end
+  end
+
+  def test_switch_respects_stop_new_assignment_timestamp_even_after_assignment
+    e = Verdict::Experiment.new('test') do
+      groups do
+        group :a, :half
+        group :b, :half
+      end
+    end
+
+    assert_equal :a, e.switch(1)
+    
+    e.schedule_start_timestamp Time.new(2020, 4, 1)
+    e.schedule_stop_new_assignment_timestamp Time.new(2020, 4, 15)
+    e.schedule_end_timestamp Time.new(2020, 5, 1)
+
+    # switch respects to stop new assignment timestamp even after the assignment occurred
+    Timecop.freeze(Time.new(2020, 4, 16)) do
+      assert e.send(:is_stop_new_assignments?)
+      assert_nil e.switch(1)
+    end
+  end
+
+  def test_not_is_stop_new_assignment_when_timestamp_not_in_schedule
+    e = Verdict::Experiment.new('test') do
+      groups do
+        group :a, :half
+        group :b, :half
+      end
+      schedule_start_timestamp Time.new(2020, 1, 1)
+      schedule_stop_new_assignment_timestamp Time.new(2019, 12, 1)
+      schedule_end_timestamp Time.new(2020, 2, 1)
+    end
+
+    #stop new timestamp not within interval
+    Timecop.freeze(Time.new(2020, 1, 16)) do
+      assert !e.send(:is_stop_new_assignments?)
     end
   end
   private

--- a/test/experiment_test.rb
+++ b/test/experiment_test.rb
@@ -598,7 +598,7 @@ class ExperimentTest < Minitest::Test
 
     e.schedule_stop_new_assignment_timestamp Time.new(2020, 4, 15)
 
-    # switch respects to stop new assignment timestamp even after the assignment occurred
+    # switch respects to stop new assignment timestamp, old assignment preserves, new assignment returns nil
     Timecop.freeze(Time.new(2020, 4, 16)) do
       assert !e.send(:is_make_new_assignments?)
       # old assignment stay the same

--- a/test/experiment_test.rb
+++ b/test/experiment_test.rb
@@ -565,6 +565,24 @@ class ExperimentTest < Minitest::Test
     end
   end
 
+  def test_is_stopped_new_assignment
+    e = Verdict::Experiment.new('test') do
+      groups do
+        group :a, :half
+        group :b, :half
+      end
+      schedule_stop_new_assignment_timestamp Time.new(2020, 1, 1)
+    end
+
+    # new assignments stopped after the stop timestamp
+    Timecop.freeze(Time.new(2020, 1, 2)) do
+      assert e.send(:is_stopped_new_assignments?)
+    end
+    # new assignments didn't stop before the stop timestamp
+    Timecop.freeze(Time.new(2019, 12, 30)) do
+      assert !e.send(:is_stopped_new_assignments?)
+    end
+  end
   private
 
   def redis


### PR DESCRIPTION
Step one for this issue: https://github.com/Shopify/experiments/issues/332

Implement the `schedule_stop_analysis_timestamp` and `is_stopped_new_assignments?` method for Verdict experiment.

The reason we want to do this is: Users need to stop the new assignments to the experiment as they could have a "cooldown" period for their experiment analysis. The experiment has not ended yet, the `switch` method will not assign any subject into new groups. 

**Test cases:**
1. test if the `is_stop_new_assignments` flag worked as expected.
2. test if start or end timestamp is missing, `is_stop_new_assignments` wouldn't work as expected.
3. test if an assignment has already occurred, it will still respect `stop_new_assignment` timestamp

cc @Shopify/experiments 