### PR TITLE
Prepare release for 0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## v0.14.0
-* Add optional experiment definition method `schedule_stop_new_assignment_timestamp` to support limiting experiment's assignment lifetime with another pre-determined time interval. It allows users to have an assignment cooldown period for stable analysis of the experiment results. Experiment's lifetime now becomes: start timestamp -> stop assignment timestamp -> end timestamp. 
+* Add optional experiment definition method `schedule_stop_new_assignment_timestamp` to support limiting experiment's assignment lifetime with another pre-determined time interval. It allows users to have an assignment cooldown period for stable analysis of the experiment results. Experiment's lifetime now becomes: start experiment -> stop new assignments -> end experiment. 
 
 ## v0.13.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## v0.14.0
+* Add optional experiment definition method `schedule_stop_new_assignment_timestamp` to support limiting experiment's assignment lifetime with another pre-determined time interval. It allows users to have an assignment cooldown period for stable analysis of the experiment results. Experiment's lifetime now becomes: start timestamp -> stop assignment timestamp -> end timestamp. 
+
 ## v0.13.0
 
 * Add optional experiment definition methods `schedule_start_timestamp` and `schedule_end_timestamp` to support limiting experiment's lifetime in a pre-determined time interval.

--- a/lib/verdict/version.rb
+++ b/lib/verdict/version.rb
@@ -1,3 +1,3 @@
 module Verdict
-  VERSION = "0.13.0"
+  VERSION = "0.14.0"
 end


### PR DESCRIPTION
Prerequisite: https://github.com/Shopify/verdict/pull/68 and https://github.com/Shopify/verdict/pull/70

Release the `schedule_stop_new_assignment_timestamp` with verdict `0.14.0`.

cc @Shopify/experiments 