### PR TITLE
Handle start, end and stop_new_timestamp's inclusion and exclusion 

### DIFF
--- a/lib/verdict/experiment.rb
+++ b/lib/verdict/experiment.rb
@@ -283,13 +283,13 @@ class Verdict::Experiment
     if @schedule_start_timestamp && @schedule_start_timestamp > Time.now
       return false
     end
-    if @schedule_end_timestamp && @schedule_end_timestamp < Time.now
+    if @schedule_end_timestamp && @schedule_end_timestamp <= Time.now
       return false
     end
     return true
   end
 
   def is_make_new_assignments?
-    return !(@schedule_stop_new_assignment_timestamp && @schedule_stop_new_assignment_timestamp < Time.now)
+    return !(@schedule_stop_new_assignment_timestamp && @schedule_stop_new_assignment_timestamp <= Time.now)
   end
 end

--- a/test/experiment_test.rb
+++ b/test/experiment_test.rb
@@ -629,9 +629,9 @@ class ExperimentTest < Minitest::Test
     # stop_new_assignment_timestamp is included
     Timecop.freeze(Time.new(2020, 1, 15)) do
       assert !e.send(:is_make_new_assignments?)
-      #old assignment preserved
+      # old assignment preserved
       assert_equal :a, e.switch(1)
-      #new assignment returns nil
+      # new assignment returns nil
       assert_nil e.switch(2)
     end
 

--- a/test/experiment_test.rb
+++ b/test/experiment_test.rb
@@ -608,6 +608,39 @@ class ExperimentTest < Minitest::Test
     end
   end
 
+  def test_schedule_start_timestamp_and_stop_new_assignemnt_timestamp_are_inclusive_but_end_timestamp_is_exclusive
+    e = Verdict::Experiment.new('test') do
+      groups do
+        group :a, :half
+        group :b, :half
+      end
+
+      schedule_start_timestamp Time.new(2020, 1, 1)
+      schedule_stop_new_assignment_timestamp Time.new(2020, 1, 15)
+      schedule_end_timestamp Time.new(2020, 1, 31)
+    end
+
+    # start_timestamp is included
+    Timecop.freeze(Time.new(2020, 1, 1)) do
+      assert e.send(:is_scheduled?)
+      assert_equal :a, e.switch(1)
+    end
+
+    # stop_new_assignment_timestamp is included
+    Timecop.freeze(Time.new(2020, 1, 15)) do
+      assert !e.send(:is_make_new_assignments?)
+      #old assignment preserved
+      assert_equal :a, e.switch(1)
+      #new assignment returns nil
+      assert_nil e.switch(2)
+    end
+
+    # end_timestamp is excluded
+    Timecop.freeze(Time.new(2020, 1, 31)) do
+      assert !e.send(:is_scheduled?)
+      assert_nil e.switch(1)
+    end
+  end
   private
 
   def redis


### PR DESCRIPTION
Part of https://github.com/Shopify/experiments/issues/332

As a discussion with @Prabhashishsingh and the design for EXP new dashboard's creation page: https://github.com/Shopify/experiments/issues/292, we want the `start_timestamp`, `end_timestamp` and `stop_new_assignment_timestamp` has the following inclusion and exclusion characteristics:
1. The time interval from `start_timestamp` to `end_timestamp` (aka experiment schedule time period), 
`start_timestamp` should be **included**, but `end_timestamp` should be **excluded**. 
Example:
An Experiment start from `2020-04-01` to `2020-04-30`. From `2020-04-01 12:00 am`, experiment assignment should start, and before `2020-04-30 12:00 am`, experiment assignment should stop.

2. The time interval from `stop_new_assignment_timestamp` to `end_timestamp` (aka experiment cooldown period), `stop_new_assignment_timestamp` should be **included**, `end_timestamp` should be **excluded**.
Example:
An experiment has cooldown period from `2020-04-15` to `2020-04-30`. From `2020-04-15 12:00 am`, and before `2020-04-30 12:00 am`, there should be no new assignment occurring.

cc @Shopify/experiments 