### PR TITLE
Allow qualifiers in switch

### DIFF
--- a/test/experiment_test.rb
+++ b/test/experiment_test.rb
@@ -641,6 +641,39 @@ class ExperimentTest < Minitest::Test
       assert_nil e.switch(1)
     end
   end
+
+  def test_custom_qualifiers_success
+    e = Verdict::Experiment.new('test') do
+      groups do
+        group :all, 100
+      end
+    end
+
+    subject = 2
+    custom_qualifier_a = Proc.new { |subject| subject.even? }
+    custom_qualifier_b = Proc.new { |subject| subject > 0 }
+
+    group = e.switch(subject, qualifiers: [custom_qualifier_a, custom_qualifier_b])
+    assert_equal e.group(:all).to_sym, group
+  end
+
+  def test_custom_qualifiers_failure
+    e = Verdict::Experiment.new('test') do
+      groups do
+        group :all, 100
+      end
+    end
+
+    subject = 3
+    custom_qualifier_a = Proc.new { |subject| subject.even? }
+    custom_qualifier_b = Proc.new { |subject| subject > 0 }
+
+    e.switch(subject, qualifiers: [custom_qualifier_a, custom_qualifier_b])
+
+    group = e.switch(subject, qualifiers: [custom_qualifier_a, custom_qualifier_b])
+    assert_nil group
+  end
+
   private
 
   def redis


### PR DESCRIPTION
Dev portion of: https://github.com/Shopify/experiments/issues/505

This adds another param to the `switch` method. This `qualifier` param allows the user to pass in custom qualifiers outside of the original experiment definition. 