### PR TITLE
Add default for dynamic_qualifiers

### DIFF
--- a/lib/verdict/experiment.rb
+++ b/lib/verdict/experiment.rb
@@ -243,7 +243,7 @@ class Verdict::Experiment
     @disqualify_empty_identifier
   end
 
-  def subject_qualifies?(subject, dynamic_qualifiers, context = nil)
+  def subject_qualifies?(subject, dynamic_qualifiers = [], context = nil)
     ensure_experiment_has_started
     return false unless dynamic_qualifiers.all? { |qualifier| qualifier.call(subject) }
     everybody_qualifies? || @qualifiers.all? { |qualifier| qualifier.call(subject, context) }


### PR DESCRIPTION
#72 modified the `subject_qualifies?` method to add another parameter. This parameter was not given a default value, and thus broke for users that were calling this method directly. This PR adds a default value for the method, remedying this issue. 