### PR TITLE
Allow using a ConnectionPool object for the Redis storage

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ source 'https://rubygems.org'
 gemspec
 gem "rubysl", platform: :rbx
 gem "json", platform: :rbx
+gem "connection_pool"
 
 group :development do
   gem "simplecov", platforms: [:mri, :jruby]

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,6 @@ source 'https://rubygems.org'
 gemspec
 gem "rubysl", platform: :rbx
 gem "json", platform: :rbx
-gem "connection_pool"
 
 group :development do
   gem "simplecov", platforms: [:mri, :jruby]

--- a/lib/verdict/storage/redis_storage.rb
+++ b/lib/verdict/storage/redis_storage.rb
@@ -28,24 +28,24 @@ module Verdict
       end
 
       def get(scope, key)
-        redis.with do |r|
-          r.hget(scope_key(scope), key)
+        redis.with do |conn|
+          conn.hget(scope_key(scope), key)
         end
       rescue ::Redis::BaseError => e
         raise Verdict::StorageError, "Redis error: #{e.message}"
       end
 
       def set(scope, key, value)
-        redis.with do |r|
-          r.hset(scope_key(scope), key, value)
+        redis.with do |conn|
+          conn.hset(scope_key(scope), key, value)
         end
       rescue ::Redis::BaseError => e
         raise Verdict::StorageError, "Redis error: #{e.message}"
       end
 
       def remove(scope, key)
-        redis.with do |r|
-          r.hdel(scope_key(scope), key)
+        redis.with do |conn|
+          conn.hdel(scope_key(scope), key)
         end
       rescue ::Redis::BaseError => e
         raise Verdict::StorageError, "Redis error: #{e.message}"
@@ -53,8 +53,8 @@ module Verdict
 
       def clear(scope, options)
         scrub(scope)
-        redis.with do |r|
-          r.del(scope_key(scope))
+        redis.with do |conn|
+          conn.del(scope_key(scope))
         end
       rescue ::Redis::BaseError => e
         raise Verdict::StorageError, "Redis error: #{e.message}"
@@ -67,8 +67,8 @@ module Verdict
       end
 
       def scrub(scope, cursor: 0)
-        cursor, results = redis.with do |r|
-          r.hscan(scope_key(scope), cursor, count: PAGE_SIZE)
+        cursor, results = redis.with do |conn|
+          conn.hscan(scope_key(scope), cursor, count: PAGE_SIZE)
         end
 
         results.map(&:first).each do |key|

--- a/lib/verdict/storage/redis_storage.rb
+++ b/lib/verdict/storage/redis_storage.rb
@@ -7,32 +7,48 @@ module Verdict
 
       def initialize(redis = nil, options = {})
         @redis = redis
+        redis.extend(ConnectionPoolLike) if !redis.nil? && !redis.respond_to?(:with)
+
         @key_prefix = options[:key_prefix] || 'experiments/'
       end
 
       protected
 
+      module ConnectionPoolLike
+        def with
+          yield self
+        end
+      end
+
       def get(scope, key)
-        redis.hget(scope_key(scope), key)
+        redis.with do |r|
+          r.hget(scope_key(scope), key)
+        end
       rescue ::Redis::BaseError => e
         raise Verdict::StorageError, "Redis error: #{e.message}"
       end
 
       def set(scope, key, value)
-        redis.hset(scope_key(scope), key, value)
+        redis.with do |r|
+          r.hset(scope_key(scope), key, value)
+        end
       rescue ::Redis::BaseError => e
         raise Verdict::StorageError, "Redis error: #{e.message}"
       end
 
       def remove(scope, key)
-        redis.hdel(scope_key(scope), key)
+        redis.with do |r|
+          r.hdel(scope_key(scope), key)
+        end
       rescue ::Redis::BaseError => e
         raise Verdict::StorageError, "Redis error: #{e.message}"
       end
 
       def clear(scope, options)
         scrub(scope)
-        redis.del(scope_key(scope))
+        redis.with do |r|
+          r.del(scope_key(scope))
+        end
       rescue ::Redis::BaseError => e
         raise Verdict::StorageError, "Redis error: #{e.message}"
       end
@@ -44,10 +60,14 @@ module Verdict
       end
 
       def scrub(scope, cursor: 0)
-        cursor, results = redis.hscan(scope_key(scope), cursor, count: PAGE_SIZE)
+        cursor, results = redis.with do |r|
+          r.hscan(scope_key(scope), cursor, count: PAGE_SIZE)
+        end
+
         results.map(&:first).each do |key|
           remove(scope, key)
         end
+
         scrub(scope, cursor: cursor) unless cursor.to_i.zero?
       end
     end

--- a/lib/verdict/storage/redis_storage.rb
+++ b/lib/verdict/storage/redis_storage.rb
@@ -6,17 +6,24 @@ module Verdict
       attr_accessor :redis, :key_prefix
 
       def initialize(redis = nil, options = {})
-        @redis = redis
-        redis.extend(ConnectionPoolLike) if !redis.nil? && !redis.respond_to?(:with)
+        if !redis.nil? && !redis.respond_to?(:with)
+          @redis = ConnectionPoolLike.new(redis)
+        else
+          @redis = redis
+        end
 
         @key_prefix = options[:key_prefix] || 'experiments/'
       end
 
       protected
 
-      module ConnectionPoolLike
+      class ConnectionPoolLike
+        def initialize(redis)
+          @redis = redis
+        end
+
         def with
-          yield self
+          yield @redis
         end
       end
 

--- a/test/storage/redis_storage_test.rb
+++ b/test/storage/redis_storage_test.rb
@@ -1,6 +1,86 @@
 require 'test_helper'
 
+
+module SharedRedisStorageTests
+  attr_reader :redis, :experiment, :storage
+
+  def test_store_and_retrieve_qualified_assignment
+    refute redis.hexists(experiment_key, 'assignment_subject_1')
+
+    new_assignment = experiment.assign('subject_1')
+    assert new_assignment.qualified?
+    refute new_assignment.returning?
+
+    assert redis.hexists(experiment_key, 'assignment_subject_1')
+
+    returning_assignment = experiment.assign('subject_1')
+    assert returning_assignment.returning?
+    assert_equal new_assignment.experiment, returning_assignment.experiment
+    assert_equal new_assignment.group, returning_assignment.group
+  end
+
+  def test_store_and_retrieve_unqualified_assignment
+    refute redis.hexists(experiment_key, 'assignment_subject_2')
+
+    new_assignment = experiment.assign('subject_2')
+
+    refute new_assignment.returning?
+    refute new_assignment.qualified?
+    assert redis.hexists(experiment_key, 'assignment_subject_2')
+
+    returning_assignment = experiment.assign('subject_2')
+    assert returning_assignment.returning?
+    assert_equal new_assignment.experiment, returning_assignment.experiment
+    assert_nil new_assignment.group
+    assert_nil returning_assignment.group
+  end
+
+  def test_remove_subject_assignment
+    experiment.assign('subject_3')
+    assert redis.hexists(experiment_key, 'assignment_subject_3')
+    experiment.remove_subject_assignment('subject_3')
+    refute redis.hexists(experiment_key, 'assignment_subject_3')
+  end
+
+  def test_started_at
+    refute redis.hexists(experiment_key, "started_at")
+    a = experiment.send(:ensure_experiment_has_started)
+    assert redis.hexists(experiment_key, "started_at")
+    assert_equal a, experiment.started_at
+  end
+
+  def test_cleanup_with_scope_argument
+    1000.times do |n|
+      experiment.assign("something_#{n}")
+    end
+
+    assert_operator redis, :exists, experiment_key
+
+    Verdict.default_logger.expects(:warn).with(regexp_matches(/deprecated/))
+    storage.cleanup(:redis_storage)
+    refute_operator redis, :exists, experiment_key
+  end
+
+  def test_cleanup
+    1000.times do |n|
+      experiment.assign("something_#{n}")
+    end
+
+    assert_operator redis, :exists, experiment_key
+
+    storage.cleanup(experiment)
+    refute_operator redis, :exists, experiment_key
+  end
+
+  private
+
+  def experiment_key
+    "experiments/redis_storage"
+  end
+end
+
 class RedisStorageTest < Minitest::Test
+  include SharedRedisStorageTests
 
   def setup
     @redis = ::Redis.new(host: REDIS_HOST, port: REDIS_PORT)
@@ -16,44 +96,42 @@ class RedisStorageTest < Minitest::Test
     @redis.del('experiments/redis_storage')
   end
 
-  def test_store_and_retrieve_qualified_assignment
-    refute @redis.hexists(experiment_key, 'assignment_subject_1')
-
-    new_assignment = @experiment.assign('subject_1')
-    assert new_assignment.qualified?
-    refute new_assignment.returning?
-
-    assert @redis.hexists(experiment_key, 'assignment_subject_1')
-
-    returning_assignment = @experiment.assign('subject_1')
-    assert returning_assignment.returning?
-    assert_equal new_assignment.experiment, returning_assignment.experiment
-    assert_equal new_assignment.group, returning_assignment.group
-  end
-
-  def test_store_and_retrieve_unqualified_assignment
-    refute @redis.hexists(experiment_key, 'assignment_subject_2')
-
-    new_assignment = @experiment.assign('subject_2')
-
-    refute new_assignment.returning?
-    refute new_assignment.qualified?
-    assert @redis.hexists(experiment_key, 'assignment_subject_2')
-
-    returning_assignment = @experiment.assign('subject_2')
-    assert returning_assignment.returning?
-    assert_equal new_assignment.experiment, returning_assignment.experiment
-    assert_nil new_assignment.group
-    assert_nil returning_assignment.group
-  end
-
   def test_assign_should_return_unqualified_when_redis_is_unavailable_for_reads
-    @redis.stubs(:hget).raises(::Redis::BaseError, "Redis is down")
-    assert !@experiment.assign('subject_1').qualified?
+    redis.stubs(:hget).raises(::Redis::BaseError, "Redis is down")
+    assert !experiment.assign('subject_1').qualified?
   end
 
   def test_assign_should_return_unqualified_when_redis_is_unavailable_for_writes
-    @redis.stubs(:hset).raises(::Redis::BaseError, "Redis is down")
+    redis.stubs(:hset).raises(::Redis::BaseError, "Redis is down")
+    assert !experiment.assign('subject_1').qualified?
+  end
+end
+
+class RedisStorageConnectionPoolTest < Minitest::Test
+  include SharedRedisStorageTests
+
+  def setup
+    @redis = ::Redis.new(host: REDIS_HOST, port: REDIS_PORT)
+    @redis_pool = ::ConnectionPool.new(size: 3) do
+      ::Redis.new(host: REDIS_HOST, port: REDIS_PORT)
+    end
+    @storage = storage = Verdict::Storage::RedisStorage.new(@redis_pool)
+    @experiment = Verdict::Experiment.new(:redis_storage) do
+      qualify { |s| s == 'subject_1' }
+      groups { group :all, 100 }
+      storage storage, store_unqualified: true
+    end
+  end
+
+  def teardown
+    @redis.del('experiments/redis_storage')
+  end
+
+  def test_assign_should_return_unqualified_when_redis_is_unavailable_for_writes
+    redis_mock = stub
+    redis_mock.stubs(:hget).returns(nil)
+    redis_mock.stubs(:hset).raises(::Redis::BaseError, "Redis is down")
+    @redis_pool.stubs(:with).yields(redis_mock)
     assert !@experiment.assign('subject_1').qualified?
   end
 
@@ -62,41 +140,5 @@ class RedisStorageTest < Minitest::Test
     assert @redis.hexists(experiment_key, 'assignment_subject_3')
     @experiment.remove_subject_assignment('subject_3')
     refute @redis.hexists(experiment_key, 'assignment_subject_3')
-  end
-
-  def test_started_at
-    refute @redis.hexists(experiment_key, "started_at")
-    a = @experiment.send(:ensure_experiment_has_started)
-    assert @redis.hexists(experiment_key, "started_at")
-    assert_equal a, @experiment.started_at
-  end
-
-  def test_cleanup_with_scope_argument
-    1000.times do |n|
-      @experiment.assign("something_#{n}")
-    end
-
-    assert_operator @redis, :exists, experiment_key
-
-    Verdict.default_logger.expects(:warn).with(regexp_matches(/deprecated/))
-    @storage.cleanup(:redis_storage)
-    refute_operator @redis, :exists, experiment_key
-  end
-
-  def test_cleanup
-    1000.times do |n|
-      @experiment.assign("something_#{n}")
-    end
-
-    assert_operator @redis, :exists, experiment_key
-
-    @storage.cleanup(@experiment)
-    refute_operator @redis, :exists, experiment_key
-  end
-
-  private
-
-  def experiment_key
-    "experiments/redis_storage"
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -13,6 +13,7 @@ require "mocha/setup"
 require "timecop"
 require "verdict"
 require "redis"
+require "connection_pool"
 
 REDIS_HOST = ENV['REDIS_HOST'].nil? ? '127.0.0.1' : ENV['REDIS_HOST']
 REDIS_PORT = (ENV['REDIS_PORT'].nil? ? '6379' : ENV['REDIS_PORT']).to_i

--- a/verdict.gemspec
+++ b/verdict.gemspec
@@ -25,4 +25,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency("timecop")
   gem.add_development_dependency("redis")
   gem.add_development_dependency("rails")
+  gem.add_development_dependency("connection_pool")
 end


### PR DESCRIPTION
Currently apps are required to pass in a single `Redis` connection object. If the service is using Sidekiq or Puma, it's likely to be using multiple threads, and thus concurrent access to Verdict storage may cause waiting. By allowing the app to pass in a [`ConnectionPool`](https://github.com/mperham/connection_pool) instead, multiple threads can concurrently access the Redis.