### PR TITLE
Bump CI ruby versions - run 2.5, 2.6, 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,9 @@ cache: bundler
 before_install: gem update bundler
 script: bundle exec rake
 rvm:
-  - 2.0
-  - 2.1
-  - 2.3.3
+  - 2.5
+  - 2.6
+  - 2.7
   - ruby-head
   - jruby
 matrix:


### PR DESCRIPTION
2.0, 2.1, 2.3.3 are very old Ruby versions. This PR changes so that CI runs 2.5, 2.6, 2.7 instead, which I believe is what most apps would be running. Should help https://github.com/Shopify/verdict/pull/76 pass.