### PR TITLE
Add dynamic switcher for subject qualifies

### DIFF
--- a/lib/verdict/experiment.rb
+++ b/lib/verdict/experiment.rb
@@ -296,7 +296,7 @@ class Verdict::Experiment
     return !(@schedule_stop_new_assignment_timestamp && @schedule_stop_new_assignment_timestamp <= Time.now)
   end
 
-  # Used when a Experiment class has overriden the subject_qualifies? method prior to v0.15.0
+  # Used when a Experiment class has overridden the subject_qualifies? method prior to v0.15.0
   # The previous version of subject_qualifies did not accept dynamic qualifiers, thus this is used to
   # determine how many parameters to pass
   def dynamic_subject_qualifies?(subject, dynamic_qualifiers, context)

--- a/lib/verdict/experiment.rb
+++ b/lib/verdict/experiment.rb
@@ -148,7 +148,7 @@ class Verdict::Experiment
     subject_identifier = retrieve_subject_identifier(subject)
     assignment = if previous_assignment
       previous_assignment
-    elsif subject_qualifies?(subject, dynamic_qualifiers, context) && is_make_new_assignments?
+    elsif dynamic_subject_qualifies?(subject, dynamic_qualifiers, context) && is_make_new_assignments?
       group = segmenter.assign(subject_identifier, subject, context)
       subject_assignment(subject, group, nil, group.nil?)
     else
@@ -243,7 +243,7 @@ class Verdict::Experiment
     @disqualify_empty_identifier
   end
 
-  def subject_qualifies?(subject, dynamic_qualifiers = [], context = nil)
+  def subject_qualifies?(subject, context = nil, dynamic_qualifiers: [])
     ensure_experiment_has_started
     return false unless dynamic_qualifiers.all? { |qualifier| qualifier.call(subject) }
     everybody_qualifies? || @qualifiers.all? { |qualifier| qualifier.call(subject, context) }
@@ -294,5 +294,16 @@ class Verdict::Experiment
 
   def is_make_new_assignments?
     return !(@schedule_stop_new_assignment_timestamp && @schedule_stop_new_assignment_timestamp <= Time.now)
+  end
+
+  # Used when a Experiment class has overriden the subject_qualifies? method prior to v0.15.0
+  # The previous version of subject_qualifies did not accept dynamic qualifiers, thus this is used to
+  # determine how many parameters to pass
+  def dynamic_subject_qualifies?(subject, dynamic_qualifiers, context)
+    if method(:subject_qualifies?).parameters.include?([:key, :dynamic_qualifiers])
+      subject_qualifies?(subject, context, dynamic_qualifiers: dynamic_qualifiers)
+    else
+      subject_qualifies?(subject, context)
+    end
   end
 end

--- a/test/experiment_test.rb
+++ b/test/experiment_test.rb
@@ -668,9 +668,18 @@ class ExperimentTest < Minitest::Test
     custom_qualifier_a = Proc.new { |subject| subject.even? }
     custom_qualifier_b = Proc.new { |subject| subject > 0 }
 
-    e.switch(subject, qualifiers: [custom_qualifier_a, custom_qualifier_b])
-
     group = e.switch(subject, qualifiers: [custom_qualifier_a, custom_qualifier_b])
+    assert_nil group
+  end
+
+  def test_dynamic_subject_qualifies_call_overridden_method
+    e = MyExperiment.new('test') do
+      groups do
+        group :all, 100
+      end
+    end
+
+    group = e.switch(4)
     assert_nil group
   end
 
@@ -678,5 +687,12 @@ class ExperimentTest < Minitest::Test
 
   def redis
     @redis ||= ::Redis.new(host: REDIS_HOST, port: REDIS_PORT)
+  end
+end
+
+class MyExperiment < Verdict::Experiment
+  def subject_qualifies?(subject, context = nil)
+    return false if subject.even?
+    super
   end
 end


### PR DESCRIPTION
Some consumers of Verdict were manually overriding the `subject_qualifies?` method. This led to errors because as of >v0.15.0, the method signature was changed to accept 3 parameters. However, the overrided method definitions only expected 2 parameters. In order to maintain backwards compatibility, an intermediary step was added to determine which version of the `subject_qualifies?` method should be invoked.