### PR TITLE
Bump version to v0.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## v0.16.0
+* Allow configuring the `RedisStorage` with a [`ConnectionPool`](https://github.com/mperham/connection_pool) instead of a raw `Redis` connection.
+
 ## v0.15.2
 * Fix edge case where inheriting from `Verdict::Experiment` and overriding `subject_qualifies?` resulted in an error.
 

--- a/lib/verdict/version.rb
+++ b/lib/verdict/version.rb
@@ -1,3 +1,3 @@
 module Verdict
-  VERSION = "0.15.2"
+  VERSION = "0.16.0"
 end


### PR DESCRIPTION
To release https://github.com/Shopify/verdict/pull/76.