### PR TITLE
Make scrub be iterative instead of recursive so it does not throw a stack level too deep error for big experiments

### DIFF
--- a/lib/verdict/storage/redis_storage.rb
+++ b/lib/verdict/storage/redis_storage.rb
@@ -67,15 +67,17 @@ module Verdict
       end
 
       def scrub(scope, cursor: 0)
-        cursor, results = redis.with do |conn|
-          conn.hscan(scope_key(scope), cursor, count: PAGE_SIZE)
-        end
+        loop do
+          cursor, results = redis.with do |conn|
+            conn.hscan(scope_key(scope), cursor, count: PAGE_SIZE)
+          end
 
-        results.map(&:first).each do |key|
-          remove(scope, key)
-        end
+          results.map(&:first).each do |key|
+            remove(scope, key)
+          end
 
-        scrub(scope, cursor: cursor) unless cursor.to_i.zero?
+          break if cursor.to_i.zero?
+        end
       end
     end
   end


### PR DESCRIPTION
We have a couple big experiments (+1GB in assigments). Our redis storage is filling up, so we created a task to remove stale experiments. It basically creates a Verdict experiment on the fly for the handle and calls `cleanup` on it.

That's calling `scrub`, which is recursive, and it's throwing `stack level too deep` errors, halting the process. This changes the scrub method to be iterative instead.