### PR TITLE
CookieStorage: Mock request in tests to support changes in Rails 6.1

### DIFF
--- a/test/storage/cookie_storage_test.rb
+++ b/test/storage/cookie_storage_test.rb
@@ -6,7 +6,9 @@ require 'fake_app'
 class CookieStorageTest < Minitest::Test
   def setup
     @storage = Verdict::Storage::CookieStorage.new.tap do |s|
-      s.cookies = ActionDispatch::Cookies::CookieJar.new(nil)
+      request = mock()
+      request.stubs(:cookies_same_site_protection).returns(proc { :none })
+      s.cookies = ActionDispatch::Cookies::CookieJar.new(request)
     end
     @experiment = Verdict::Experiment.new(:cookie_storage_test) do
       groups { group :all, 100 }


### PR DESCRIPTION
We're using an internal Rails class in tests which made our tests break with the release of Rails 6.1.
This PR mocks the request in CookieStorageTest to support this change.

Ideally we should move away from using internal Rails classes but thats for another PR.